### PR TITLE
feat: add fieldmask package with UpdateTopLevelFields

### DIFF
--- a/fieldmask/doc.go
+++ b/fieldmask/doc.go
@@ -1,0 +1,8 @@
+// Package fieldmask provides primitives for implementing AIP field mask functionality.
+//
+// This package only provides primitives not already provided by the package
+// google.golang.org/protobuf/types/known/fieldmaskpb.
+//
+// See: https://google.aip.dev/134 (Standard methods: Update)
+// See: https://google.aip.dev/157 (Partial responses)
+package fieldmask

--- a/fieldmask/update.go
+++ b/fieldmask/update.go
@@ -1,0 +1,55 @@
+package fieldmask
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// UpdateTopLevelFields updates the top-level fields in dst with values from src according to the provided field mask.
+//
+// Nested messages are copied by reference from src to dst.
+// If no update mask is provided, only non-zero values of src are copied to dst.
+// If the special value "*" is provided as the field mask, a full replacement of all fields in dst is done.
+//
+// See: https://google.aip.dev/134 (Standard methods: Update).
+func UpdateTopLevelFields(mask *fieldmaskpb.FieldMask, dst, src proto.Message) {
+	dstReflect := dst.ProtoReflect()
+	srcReflect := src.ProtoReflect()
+	if dstReflect.Descriptor() != srcReflect.Descriptor() {
+		panic(fmt.Sprintf(
+			"dst (%s) and src (%s) messages have different types",
+			dstReflect.Descriptor().FullName(),
+			srcReflect.Descriptor().FullName(),
+		))
+	}
+	switch {
+	// Special-case: No update mask.
+	// Update all fields of src that are set on the wire.
+	case len(mask.GetPaths()) == 0:
+		srcReflect.Range(func(field protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+			dstReflect.Set(field, value)
+			return true
+		})
+	// Special-case: Update mask is [*].
+	// Do a full replacement of all fields.
+	case len(mask.GetPaths()) == 1 && mask.GetPaths()[0] == "*":
+		proto.Reset(dst)
+		proto.Merge(dst, src)
+	default:
+		fields := srcReflect.Descriptor().Fields()
+		for _, path := range mask.GetPaths() {
+			if isTopLevelField := !strings.ContainsRune(path, '.'); !isTopLevelField {
+				continue // skip non-top-level fields
+			}
+			field := fields.ByName(protoreflect.Name(path))
+			if field == nil {
+				continue // no known field by that name
+			}
+			dstReflect.Set(field, srcReflect.Get(field))
+		}
+	}
+}

--- a/fieldmask/update_test.go
+++ b/fieldmask/update_test.go
@@ -1,0 +1,170 @@
+package fieldmask
+
+import (
+	"testing"
+
+	"google.golang.org/genproto/googleapis/example/library/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestUpdateTopLevelFields(t *testing.T) {
+	t.Parallel()
+	t.Run("should panic on different src and dst", func(t *testing.T) {
+		t.Parallel()
+		assert.Assert(t, cmp.Panics(func() {
+			UpdateTopLevelFields(&fieldmaskpb.FieldMask{}, &library.Book{}, &library.Shelf{})
+		}))
+	})
+
+	t.Run("test cases", func(t *testing.T) {
+		t.Parallel()
+		for _, tt := range []struct {
+			name     string
+			mask     *fieldmaskpb.FieldMask
+			src      proto.Message
+			dst      proto.Message
+			expected proto.Message
+		}{
+			{
+				name: "full replacement",
+				mask: &fieldmaskpb.FieldMask{
+					Paths: []string{"*"},
+				},
+				src: &library.Book{
+					Name:   "src-name",
+					Author: "src-author",
+					Title:  "src-title",
+					Read:   false,
+				},
+				dst: &library.Book{
+					Name:   "dst-name",
+					Author: "dst-author",
+					Title:  "dst-title",
+					Read:   true,
+				},
+				expected: &library.Book{
+					Name:   "src-name",
+					Author: "src-author",
+					Title:  "src-title",
+					Read:   false,
+				},
+			},
+
+			{
+				name: "no field mask replaces non-zero fields",
+				mask: nil,
+				src: &library.Book{
+					Name:   "src-name",
+					Author: "src-author",
+				},
+				dst: &library.Book{
+					Name:   "dst-name",
+					Author: "dst-author",
+					Title:  "dst-title",
+					Read:   true,
+				},
+				expected: &library.Book{
+					Name:   "src-name",
+					Author: "src-author",
+					Title:  "dst-title",
+					Read:   true,
+				},
+			},
+
+			{
+				name: "with partial field mask",
+				mask: &fieldmaskpb.FieldMask{
+					Paths: []string{"name", "author", "read"},
+				},
+				src: &library.Book{
+					Name:   "src-name",
+					Author: "src-author",
+					Title:  "src-title",
+					Read:   false,
+				},
+				dst: &library.Book{
+					Name:   "dst-name",
+					Author: "dst-author",
+					Title:  "dst-title",
+					Read:   true,
+				},
+				expected: &library.Book{
+					Name:   "src-name",
+					Author: "src-author",
+					Title:  "dst-title",
+					Read:   false,
+				},
+			},
+
+			{
+				name: "with non-top-level path",
+				mask: &fieldmaskpb.FieldMask{
+					Paths: []string{"name", "book.name"},
+				},
+				src: &library.CreateBookRequest{
+					Name: "src-shelf",
+					Book: &library.Book{
+						Name:   "src-name",
+						Author: "src-author",
+						Title:  "src-title",
+						Read:   false,
+					},
+				},
+				dst: &library.CreateBookRequest{
+					Name: "dst-shelf",
+					Book: &library.Book{
+						Name:   "dst-name",
+						Author: "dst-author",
+						Title:  "dst-title",
+						Read:   true,
+					},
+				},
+				expected: &library.CreateBookRequest{
+					Name: "src-shelf",
+					Book: &library.Book{
+						Name:   "dst-name",
+						Author: "dst-author",
+						Title:  "dst-title",
+						Read:   true,
+					},
+				},
+			},
+
+			{
+				name: "with unknown path",
+				mask: &fieldmaskpb.FieldMask{
+					Paths: []string{"name", "foo"},
+				},
+				src: &library.Book{
+					Name:   "src-name",
+					Author: "src-author",
+					Title:  "src-title",
+					Read:   false,
+				},
+				dst: &library.Book{
+					Name:   "dst-name",
+					Author: "dst-author",
+					Title:  "dst-title",
+					Read:   true,
+				},
+				expected: &library.Book{
+					Name:   "src-name",
+					Author: "dst-author",
+					Title:  "dst-title",
+					Read:   true,
+				},
+			},
+		} {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				UpdateTopLevelFields(tt.mask, tt.dst, tt.src)
+				assert.DeepEqual(t, tt.expected, tt.dst, protocmp.Transform())
+			})
+		}
+	})
+}


### PR DESCRIPTION
Supports implementation of standard Update methods where only top-level
fields are supported by the update mask.
