### PR TITLE
feat: add ordering package

### DIFF
--- a/ordering/doc.go
+++ b/ordering/doc.go
@@ -1,0 +1,4 @@
+// Package ordering provides primitives for implementing AIP ordering.
+//
+// See: https://google.aip.dev/132#ordering (Standard methods: List > Ordering).
+package ordering

--- a/ordering/orderby.go
+++ b/ordering/orderby.go
@@ -1,0 +1,102 @@
+package ordering
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// OrderBy represents an ordering directive.
+type OrderBy struct {
+	// Fields are the fields to order by.
+	Fields []Field
+}
+
+// IsValidForMessage reports whether all the ordering paths are syntactically valid and
+// refer to known fields in the specified message type.
+func (o OrderBy) IsValidForMessage(m proto.Message) bool {
+	mask := fieldmaskpb.FieldMask{
+		Paths: make([]string, 0, len(o.Fields)),
+	}
+	for _, field := range o.Fields {
+		mask.Paths = append(mask.Paths, field.Path)
+	}
+	return mask.IsValid(m)
+}
+
+// IsValidForPaths reports whether all the ordering paths are syntactically valid and
+// refer to one of the provided paths.
+func (o OrderBy) IsValidForPaths(paths ...string) bool {
+FieldLoop:
+	for _, field := range o.Fields {
+		// Assumption that len(paths) is short enough that O(n^2) is not a problem.
+		for _, path := range paths {
+			if field.Path == path {
+				continue FieldLoop
+			}
+		}
+		return false
+	}
+	return true
+}
+
+// Field represents a single ordering field.
+type Field struct {
+	// Path is the path of the field, including subfields.
+	Path string
+	// Desc indicates if the ordering of the field is descending.
+	Desc bool
+}
+
+// SubFields returns the individual subfields of the field path, including the top-level subfield.
+//
+// Subfields are specified with a . character, such as foo.bar or address.street.
+func (f Field) SubFields() []string {
+	if f.Path == "" {
+		return nil
+	}
+	return strings.Split(f.Path, ".")
+}
+
+// UnmarshalString sets o from the provided ordering string. .
+func (o *OrderBy) UnmarshalString(s string) error {
+	o.Fields = o.Fields[:0]
+	if s == "" { // fast path for no ordering
+		return nil
+	}
+	for _, r := range s {
+		if !unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '_' && r != ' ' && r != ',' && r != '.' {
+			return fmt.Errorf("unmarshal order by '%s': invalid character %s", s, strconv.QuoteRune(r))
+		}
+	}
+	fields := strings.Split(s, ",")
+	o.Fields = make([]Field, 0, len(fields))
+	for _, field := range fields {
+		parts := strings.Fields(field)
+		switch len(parts) {
+		case 1: // default ordering (ascending)
+			o.Fields = append(o.Fields, Field{Path: parts[0]})
+		case 2: // specific ordering
+			order := parts[1]
+			var desc bool
+			switch order {
+			case "asc":
+				desc = false
+			case "desc":
+				desc = true
+			default: // parse error
+				return fmt.Errorf("unmarshal order by '%s': invalid format", s)
+			}
+			o.Fields = append(o.Fields, Field{Path: parts[0], Desc: desc})
+		case 0:
+			fallthrough
+		default:
+			return fmt.Errorf("unmarshal order by '%s': invalid format", s)
+		}
+	}
+	return nil
+}

--- a/ordering/orderby_test.go
+++ b/ordering/orderby_test.go
@@ -1,0 +1,246 @@
+package ordering
+
+import (
+	"testing"
+
+	"google.golang.org/genproto/googleapis/example/library/v1"
+	"google.golang.org/protobuf/proto"
+	"gotest.tools/v3/assert"
+)
+
+func TestOrderBy_UnmarshalString(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		orderBy       string
+		expected      OrderBy
+		errorContains string
+	}{
+		{
+			orderBy:  "",
+			expected: OrderBy{},
+		},
+
+		{
+			orderBy: "foo desc, bar",
+			expected: OrderBy{
+				Fields: []Field{
+					{Path: "foo", Desc: true},
+					{Path: "bar"},
+				},
+			},
+		},
+
+		{
+			orderBy: "foo.bar",
+			expected: OrderBy{
+				Fields: []Field{
+					{Path: "foo.bar"},
+				},
+			},
+		},
+
+		{
+			orderBy: " foo , bar desc ",
+			expected: OrderBy{
+				Fields: []Field{
+					{Path: "foo"},
+					{Path: "bar", Desc: true},
+				},
+			},
+		},
+
+		{orderBy: "foo,", errorContains: "invalid format"},
+		{orderBy: ",", errorContains: "invalid "},
+		{orderBy: ",foo", errorContains: "invalid format"},
+		{orderBy: "foo/bar", errorContains: "invalid character '/'"},
+		{orderBy: "foo bar", errorContains: "invalid format"},
+	} {
+		tt := tt
+		t.Run(tt.orderBy, func(t *testing.T) {
+			t.Parallel()
+			var actual OrderBy
+			err := actual.UnmarshalString(tt.orderBy)
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+			} else {
+				assert.NilError(t, err)
+				assert.DeepEqual(t, tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestOrderBy_IsValidForMessage(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		orderBy OrderBy
+		message proto.Message
+		isValid bool
+	}{
+		{
+			name:    "valid empty",
+			orderBy: OrderBy{},
+			message: &library.Book{},
+			isValid: true,
+		},
+
+		{
+			name: "valid single",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "author"},
+				},
+			},
+			message: &library.Book{},
+			isValid: true,
+		},
+
+		{
+			name: "invalid single",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "foo"},
+				},
+			},
+			message: &library.Book{},
+			isValid: false,
+		},
+
+		{
+			name: "valid nested",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "book.name"},
+				},
+			},
+			message: &library.CreateBookRequest{},
+			isValid: true,
+		},
+
+		{
+			name: "invalid nested",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "book.foo"},
+				},
+			},
+			message: &library.CreateBookRequest{},
+			isValid: false,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.isValid, tt.orderBy.IsValidForMessage(tt.message))
+		})
+	}
+}
+
+func TestOrderBy_IsValidForPaths(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name    string
+		orderBy OrderBy
+		paths   []string
+		isValid bool
+	}{
+		{
+			name:    "valid empty",
+			orderBy: OrderBy{},
+			paths:   []string{},
+			isValid: true,
+		},
+
+		{
+			name: "valid single",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "author"},
+				},
+			},
+			paths:   []string{"name", "author", "read"},
+			isValid: true,
+		},
+
+		{
+			name: "invalid single",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "foo"},
+				},
+			},
+			paths:   []string{"name", "author", "read"},
+			isValid: false,
+		},
+
+		{
+			name: "valid nested",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "book.name"},
+				},
+			},
+			paths:   []string{"name", "book.name", "book.author", "book.read"},
+			isValid: true,
+		},
+
+		{
+			name: "invalid nested",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "book.foo"},
+				},
+			},
+			paths:   []string{"name", "book.name", "book.author", "book.read"},
+			isValid: false,
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.isValid, tt.orderBy.IsValidForPaths(tt.paths...))
+		})
+	}
+}
+
+func TestField_SubFields(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		field    Field
+		expected []string
+	}{
+		{
+			name:     "empty",
+			field:    Field{},
+			expected: nil,
+		},
+
+		{
+			name:     "single",
+			field:    Field{Path: "foo"},
+			expected: []string{"foo"},
+		},
+
+		{
+			name:     "multiple",
+			field:    Field{Path: "foo.bar"},
+			expected: []string{"foo", "bar"},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.DeepEqual(t, tt.expected, tt.field.SubFields())
+		})
+	}
+}

--- a/ordering/request.go
+++ b/ordering/request.go
@@ -1,0 +1,18 @@
+package ordering
+
+// Request is an interface for requests that support ordering.
+//
+// See: https://google.aip.dev/132#ordering (Standard methods: List > Ordering).
+type Request interface {
+	// GetOrderBy returns the ordering of the request.
+	GetOrderBy() string
+}
+
+// ParseOrderBy request parses the ordering field for a Request.
+func ParseOrderBy(r Request) (OrderBy, error) {
+	var orderBy OrderBy
+	if err := orderBy.UnmarshalString(r.GetOrderBy()); err != nil {
+		return OrderBy{}, err
+	}
+	return orderBy, nil
+}

--- a/ordering/request_test.go
+++ b/ordering/request_test.go
@@ -1,0 +1,42 @@
+package ordering
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParseOrderBy(t *testing.T) {
+	t.Parallel()
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		r := mockRequest{orderBy: "foo asc,bar desc"}
+		expected := OrderBy{
+			Fields: []Field{
+				{Path: "foo"},
+				{Path: "bar", Desc: true},
+			},
+		}
+		actual, err := ParseOrderBy(r)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, expected, actual)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+		r := mockRequest{orderBy: "/foo"}
+		actual, err := ParseOrderBy(r)
+		assert.ErrorContains(t, err, "invalid character '/'")
+		assert.DeepEqual(t, OrderBy{}, actual)
+	})
+}
+
+type mockRequest struct {
+	orderBy string
+}
+
+var _ Request = &mockRequest{}
+
+func (m mockRequest) GetOrderBy() string {
+	return m.orderBy
+}


### PR DESCRIPTION
Implementation of the `order_by` string syntax, reusable for all
standard List methods (and other places where ordering is used).

Implementation is inspired by the spansql.Order type:

https://pkg.go.dev/cloud.google.com/go/spanner/spansql#Order

...but with a field-mask style `Path` instead of an arbitrary
expression.
