### PR TITLE
feat: add filtering package and filtering.Lexer

### DIFF
--- a/filtering/doc.go
+++ b/filtering/doc.go
@@ -1,0 +1,4 @@
+// Package filtering provides primitives for implementing AIP filtering.
+//
+// See: https://google.aip.dev/160 (Filtering)
+package filtering

--- a/filtering/lexer.go
+++ b/filtering/lexer.go
@@ -1,0 +1,150 @@
+package filtering
+
+import (
+	"fmt"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Lexer is a filter expression lexer.
+type Lexer struct {
+	filter string
+	// current state
+	err          error
+	currToken    Token
+	currTokenEnd Position
+	currRune     rune
+	// backtracking
+	prevRune     rune
+	prevToken    Token
+	prevTokenEnd Position
+}
+
+// NewLexer creates a new lexer for the provided filter expression.
+func NewLexer(filter string) *Lexer {
+	return &Lexer{
+		filter:       filter,
+		currToken:    Token{Position: Position{Offset: 0, Line: 1, Column: 1}},
+		currTokenEnd: Position{Offset: 0, Line: 1, Column: 1},
+	}
+}
+
+// Token returns the current token in the filter expression.
+func (l *Lexer) Token() Token {
+	return l.currToken
+}
+
+// Err returns any error that was encountered during lexing of the filter expression.
+func (l *Lexer) Err() error {
+	return l.err
+}
+
+// Lex advances the lexer to the next token in the filter expression.
+func (l *Lexer) Lex() bool {
+	l.currToken = Token{Position: l.currTokenEnd}
+	l.prevTokenEnd = l.currTokenEnd
+	l.prevToken = l.currToken
+	if !l.readRune() {
+		return false
+	}
+	switch l.currRune {
+	// Single-character operator?
+	case '(', ')', '-', '.', '=', ':', ',':
+		return l.emit(TokenType(l.currToken.Value))
+	// Two-character operator?
+	case '<', '>', '!':
+		if !l.readRune() || l.currRune == '=' {
+			return l.emit(TokenType(l.currToken.Value))
+		}
+		// Not a two-character operator. Back up and emit single-character operator.
+		l.unreadRune()
+		return l.emit(TokenType(l.currToken.Value))
+	// Read string?
+	case '\'', '"':
+		delimiter := l.currRune
+		for l.readRune() && l.currRune != delimiter {
+			// Read until the closing delimiter.
+		}
+		if l.currRune != delimiter {
+			return l.errorf("unterminated string")
+		}
+		return l.emit(TokenTypeString)
+	}
+	// Read whitespace?
+	if unicode.IsSpace(l.currRune) {
+		for l.readRune() {
+			if !unicode.IsSpace(l.currRune) {
+				l.unreadRune()
+				break
+			}
+		}
+		return l.emit(TokenTypeWhitespace)
+	}
+	// Read text.
+	for l.readRune() {
+		switch {
+		// Got a keyword?
+		case unicode.IsSpace(l.currRune):
+			l.unreadRune()
+			switch l.currToken.Value {
+			case "NOT", "AND", "OR":
+				return l.emit(TokenType(l.currToken.Value))
+			}
+			return l.emit(TokenTypeText)
+		// End of text?
+		case !isText(l.currRune):
+			l.unreadRune()
+			return l.emit(TokenTypeText)
+		}
+	}
+	return l.emit(TokenTypeText)
+}
+
+func (l *Lexer) emit(t TokenType) bool {
+	l.currToken.Type = t
+	return true
+}
+
+func (l *Lexer) errorf(format string, a ...interface{}) bool {
+	l.err = fmt.Errorf(format, a...)
+	return false
+}
+
+func (l *Lexer) eof() bool {
+	return l.currTokenEnd.Offset >= len(l.filter)
+}
+
+func (l *Lexer) readRune() bool {
+	if l.err != nil || l.eof() {
+		return false
+	}
+	r, n := utf8.DecodeRuneInString(l.filter[l.currTokenEnd.Offset:])
+	switch {
+	case n == 0:
+		return false
+	case r == utf8.RuneError:
+		return l.errorf("invalid UTF-8")
+	}
+	// update backtracking
+	l.prevRune = l.currRune
+	l.prevToken = l.currToken
+	l.prevTokenEnd = l.currTokenEnd
+	// update current state
+	l.currRune = r
+	l.currTokenEnd.advance(r, n)
+	l.currToken.Value = l.filter[l.currToken.Position.Offset:l.currTokenEnd.Offset]
+	return n > 0
+}
+
+func (l *Lexer) unreadRune() {
+	l.currTokenEnd = l.prevTokenEnd
+	l.currToken = l.prevToken
+}
+
+func isText(r rune) bool {
+	switch r {
+	case '(', ')', '-', '.', '=', ':', '<', '>', '!', ',':
+		return false
+	}
+	return !unicode.IsSpace(r)
+}

--- a/filtering/lexer_test.go
+++ b/filtering/lexer_test.go
@@ -1,0 +1,346 @@
+package filtering
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestLexer(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		filter        string
+		expected      []Token
+		errorContains string
+	}{
+		{
+			filter: `New York Giants`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "New"},
+				{Position: Position{Offset: 3, Column: 4, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeText, Value: "York"},
+				{Position: Position{Offset: 8, Column: 9, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 9, Column: 10, Line: 1}, Type: TokenTypeText, Value: "Giants"},
+			},
+		},
+
+		{
+			filter: `New York Giants OR Yankees`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "New"},
+				{Position: Position{Offset: 3, Column: 4, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeText, Value: "York"},
+				{Position: Position{Offset: 8, Column: 9, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 9, Column: 10, Line: 1}, Type: TokenTypeText, Value: "Giants"},
+				{Position: Position{Offset: 15, Column: 16, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 16, Column: 17, Line: 1}, Type: TokenTypeOr, Value: "OR"},
+				{Position: Position{Offset: 18, Column: 19, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 19, Column: 20, Line: 1}, Type: TokenTypeText, Value: "Yankees"},
+			},
+		},
+
+		{
+			filter: `New York (Giants OR Yankees)`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "New"},
+				{Position: Position{Offset: 3, Column: 4, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeText, Value: "York"},
+				{Position: Position{Offset: 8, Column: 9, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 9, Column: 10, Line: 1}, Type: TokenTypeLeftParen, Value: "("},
+				{Position: Position{Offset: 10, Column: 11, Line: 1}, Type: TokenTypeText, Value: "Giants"},
+				{Position: Position{Offset: 16, Column: 17, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 17, Column: 18, Line: 1}, Type: TokenTypeOr, Value: "OR"},
+				{Position: Position{Offset: 19, Column: 20, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 20, Column: 21, Line: 1}, Type: TokenTypeText, Value: "Yankees"},
+				{Position: Position{Offset: 27, Column: 28, Line: 1}, Type: TokenTypeRightParen, Value: ")"},
+			},
+		},
+
+		{
+			filter: `a b AND c AND d`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "a"},
+				{Position: Position{Offset: 1, Column: 2, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 2, Column: 3, Line: 1}, Type: TokenTypeText, Value: "b"},
+				{Position: Position{Offset: 3, Column: 4, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeAnd, Value: "AND"},
+				{Position: Position{Offset: 7, Column: 8, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 8, Column: 9, Line: 1}, Type: TokenTypeText, Value: "c"},
+				{Position: Position{Offset: 9, Column: 10, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 10, Column: 11, Line: 1}, Type: TokenTypeAnd, Value: "AND"},
+				{Position: Position{Offset: 13, Column: 14, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 14, Column: 15, Line: 1}, Type: TokenTypeText, Value: "d"},
+			},
+		},
+
+		{
+			filter: `(a b) AND c AND d`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeLeftParen, Value: "("},
+				{Position: Position{Offset: 1, Column: 2, Line: 1}, Type: TokenTypeText, Value: "a"},
+				{Position: Position{Offset: 2, Column: 3, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 3, Column: 4, Line: 1}, Type: TokenTypeText, Value: "b"},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeRightParen, Value: ")"},
+				{Position: Position{Offset: 5, Column: 6, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 6, Column: 7, Line: 1}, Type: TokenTypeAnd, Value: "AND"},
+				{Position: Position{Offset: 9, Column: 10, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 10, Column: 11, Line: 1}, Type: TokenTypeText, Value: "c"},
+				{Position: Position{Offset: 11, Column: 12, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 12, Column: 13, Line: 1}, Type: TokenTypeAnd, Value: "AND"},
+				{Position: Position{Offset: 15, Column: 16, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 16, Column: 17, Line: 1}, Type: TokenTypeText, Value: "d"},
+			},
+		},
+
+		{
+			filter: `a < 10 OR a >= 100`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "a"},
+				{Position: Position{Offset: 1, Column: 2, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 2, Column: 3, Line: 1}, Type: TokenTypeLess, Value: "<"},
+				{Position: Position{Offset: 3, Column: 4, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeText, Value: "10"},
+				{Position: Position{Offset: 6, Column: 7, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 7, Column: 8, Line: 1}, Type: TokenTypeOr, Value: "OR"},
+				{Position: Position{Offset: 9, Column: 10, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 10, Column: 11, Line: 1}, Type: TokenTypeText, Value: "a"},
+				{Position: Position{Offset: 11, Column: 12, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 12, Column: 13, Line: 1}, Type: TokenTypeGreaterEquals, Value: ">="},
+				{Position: Position{Offset: 14, Column: 15, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 15, Column: 16, Line: 1}, Type: TokenTypeText, Value: "100"},
+			},
+		},
+
+		{
+			filter: `NOT (a OR b)`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeNot, Value: "NOT"},
+				{Position: Position{Offset: 3, Column: 4, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeLeftParen, Value: "("},
+				{Position: Position{Offset: 5, Column: 6, Line: 1}, Type: TokenTypeText, Value: "a"},
+				{Position: Position{Offset: 6, Column: 7, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 7, Column: 8, Line: 1}, Type: TokenTypeOr, Value: "OR"},
+				{Position: Position{Offset: 9, Column: 10, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 10, Column: 11, Line: 1}, Type: TokenTypeText, Value: "b"},
+				{Position: Position{Offset: 11, Column: 12, Line: 1}, Type: TokenTypeRightParen, Value: ")"},
+			},
+		},
+
+		{
+			filter: `-file:".java"`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeMinus, Value: "-"},
+				{Position: Position{Offset: 1, Column: 2, Line: 1}, Type: TokenTypeText, Value: "file"},
+				{Position: Position{Offset: 5, Column: 6, Line: 1}, Type: TokenTypeHas, Value: ":"},
+				{Position: Position{Offset: 6, Column: 7, Line: 1}, Type: TokenTypeString, Value: `".java"`},
+			},
+		},
+
+		{
+			filter: `-30`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeMinus, Value: "-"},
+				{Position: Position{Offset: 1, Column: 2, Line: 1}, Type: TokenTypeText, Value: "30"},
+			},
+		},
+
+		{
+			filter: `package=com.google`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "package"},
+				{Position: Position{Offset: 7, Column: 8, Line: 1}, Type: TokenTypeEquals, Value: "="},
+				{Position: Position{Offset: 8, Column: 9, Line: 1}, Type: TokenTypeText, Value: "com"},
+				{Position: Position{Offset: 11, Column: 12, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 12, Column: 13, Line: 1}, Type: TokenTypeText, Value: "google"},
+			},
+		},
+
+		{
+			filter: `msg != 'hello'`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "msg"},
+				{Position: Position{Offset: 3, Column: 4, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeNotEquals, Value: "!="},
+				{Position: Position{Offset: 6, Column: 7, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 7, Column: 8, Line: 1}, Type: TokenTypeString, Value: "'hello'"},
+			},
+		},
+
+		{
+			filter: `1 > 0`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "1"},
+				{Position: Position{Offset: 1, Column: 2, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 2, Column: 3, Line: 1}, Type: TokenTypeGreater, Value: ">"},
+				{Position: Position{Offset: 3, Column: 4, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeText, Value: "0"},
+			},
+		},
+
+		{
+			filter: `2.5 >= 2.4`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "2"},
+				{Position: Position{Offset: 1, Column: 2, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 2, Column: 3, Line: 1}, Type: TokenTypeText, Value: "5"},
+				{Position: Position{Offset: 3, Column: 4, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeGreaterEquals, Value: ">="},
+				{Position: Position{Offset: 6, Column: 7, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 7, Column: 8, Line: 1}, Type: TokenTypeText, Value: "2"},
+				{Position: Position{Offset: 8, Column: 9, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 9, Column: 10, Line: 1}, Type: TokenTypeText, Value: "4"},
+			},
+		},
+
+		{
+			filter: `yesterday < request.time`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "yesterday"},
+				{Position: Position{Offset: 9, Column: 10, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 10, Column: 11, Line: 1}, Type: TokenTypeLess, Value: "<"},
+				{Position: Position{Offset: 11, Column: 12, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 12, Column: 13, Line: 1}, Type: TokenTypeText, Value: "request"},
+				{Position: Position{Offset: 19, Column: 20, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 20, Column: 21, Line: 1}, Type: TokenTypeText, Value: "time"},
+			},
+		},
+
+		{
+			filter: `experiment.rollout <= cohort(request.user)`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "experiment"},
+				{Position: Position{Offset: 10, Column: 11, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 11, Column: 12, Line: 1}, Type: TokenTypeText, Value: "rollout"},
+				{Position: Position{Offset: 18, Column: 19, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 19, Column: 20, Line: 1}, Type: TokenTypeLessEquals, Value: "<="},
+				{Position: Position{Offset: 21, Column: 22, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 22, Column: 23, Line: 1}, Type: TokenTypeText, Value: "cohort"},
+				{Position: Position{Offset: 28, Column: 29, Line: 1}, Type: TokenTypeLeftParen, Value: "("},
+				{Position: Position{Offset: 29, Column: 30, Line: 1}, Type: TokenTypeText, Value: "request"},
+				{Position: Position{Offset: 36, Column: 37, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 37, Column: 38, Line: 1}, Type: TokenTypeText, Value: "user"},
+				{Position: Position{Offset: 41, Column: 42, Line: 1}, Type: TokenTypeRightParen, Value: ")"},
+			},
+		},
+
+		{
+			filter: `prod`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "prod"},
+			},
+		},
+
+		{
+			filter: `expr.type_map.1.type`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "expr"},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 5, Column: 6, Line: 1}, Type: TokenTypeText, Value: "type_map"},
+				{Position: Position{Offset: 13, Column: 14, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 14, Column: 15, Line: 1}, Type: TokenTypeText, Value: "1"},
+				{Position: Position{Offset: 15, Column: 16, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 16, Column: 17, Line: 1}, Type: TokenTypeText, Value: "type"},
+			},
+		},
+
+		{
+			filter: `regex(m.key, '^.*prod.*$')`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "regex"},
+				{Position: Position{Offset: 5, Column: 6, Line: 1}, Type: TokenTypeLeftParen, Value: "("},
+				{Position: Position{Offset: 6, Column: 7, Line: 1}, Type: TokenTypeText, Value: "m"},
+				{Position: Position{Offset: 7, Column: 8, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 8, Column: 9, Line: 1}, Type: TokenTypeText, Value: "key"},
+				{Position: Position{Offset: 11, Column: 12, Line: 1}, Type: TokenTypeComma, Value: ","},
+				{Position: Position{Offset: 12, Column: 13, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 13, Column: 14, Line: 1}, Type: TokenTypeString, Value: "'^.*prod.*$'"},
+				{Position: Position{Offset: 25, Column: 26, Line: 1}, Type: TokenTypeRightParen, Value: ")"},
+			},
+		},
+
+		{
+			filter: `math.mem('30mb')`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeText, Value: "math"},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 5, Column: 6, Line: 1}, Type: TokenTypeText, Value: "mem"},
+				{Position: Position{Offset: 8, Column: 9, Line: 1}, Type: TokenTypeLeftParen, Value: "("},
+				{Position: Position{Offset: 9, Column: 10, Line: 1}, Type: TokenTypeString, Value: "'30mb'"},
+				{Position: Position{Offset: 15, Column: 16, Line: 1}, Type: TokenTypeRightParen, Value: ")"},
+			},
+		},
+
+		{
+			filter: `(msg.endsWith('world') AND retries < 10)`,
+			expected: []Token{
+				{Position: Position{Offset: 0, Column: 1, Line: 1}, Type: TokenTypeLeftParen, Value: "("},
+				{Position: Position{Offset: 1, Column: 2, Line: 1}, Type: TokenTypeText, Value: "msg"},
+				{Position: Position{Offset: 4, Column: 5, Line: 1}, Type: TokenTypeDot, Value: "."},
+				{Position: Position{Offset: 5, Column: 6, Line: 1}, Type: TokenTypeText, Value: "endsWith"},
+				{Position: Position{Offset: 13, Column: 14, Line: 1}, Type: TokenTypeLeftParen, Value: "("},
+				{Position: Position{Offset: 14, Column: 15, Line: 1}, Type: TokenTypeString, Value: "'world'"},
+				{Position: Position{Offset: 21, Column: 22, Line: 1}, Type: TokenTypeRightParen, Value: ")"},
+				{Position: Position{Offset: 22, Column: 23, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 23, Column: 24, Line: 1}, Type: TokenTypeAnd, Value: "AND"},
+				{Position: Position{Offset: 26, Column: 27, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 27, Column: 28, Line: 1}, Type: TokenTypeText, Value: "retries"},
+				{Position: Position{Offset: 34, Column: 35, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 35, Column: 36, Line: 1}, Type: TokenTypeLess, Value: "<"},
+				{Position: Position{Offset: 36, Column: 37, Line: 1}, Type: TokenTypeWhitespace, Value: " "},
+				{Position: Position{Offset: 37, Column: 38, Line: 1}, Type: TokenTypeText, Value: "10"},
+				{Position: Position{Offset: 39, Column: 40, Line: 1}, Type: TokenTypeRightParen, Value: ")"},
+			},
+		},
+
+		{
+			filter:        `a = "foo`,
+			errorContains: "unterminated string",
+		},
+
+		{
+			filter:        "invalid = foo\xa0\x01bar",
+			errorContains: "invalid UTF-8",
+		},
+	} {
+		tt := tt
+		t.Run(tt.filter, func(t *testing.T) {
+			t.Parallel()
+			lexer := NewLexer(tt.filter)
+			actual := make([]Token, 0, len(tt.expected))
+			var tokenValues strings.Builder
+			tokenValues.Grow(len(tt.filter))
+			for lexer.Lex() {
+				tok := lexer.Token()
+				_, _ = tokenValues.WriteString(tok.Value)
+				actual = append(actual, tok)
+			}
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, lexer.Err(), tt.errorContains)
+			} else {
+				assert.NilError(t, lexer.Err())
+				assert.DeepEqual(t, tt.expected, actual)
+				assert.Equal(
+					t,
+					tt.filter,
+					tokenValues.String(),
+					"concatenating all token values should give the original value",
+				)
+			}
+		})
+	}
+}
+
+// nolint: gochecknoglobals
+var tokenSink Token
+
+func BenchmarkLexer_Lex(b *testing.B) {
+	const filter = `(msg.endsWith('world') AND retries < 10)`
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		lexer := NewLexer(filter)
+		for lexer.Lex() {
+			tokenSink = lexer.Token()
+		}
+	}
+}

--- a/filtering/position.go
+++ b/filtering/position.go
@@ -1,0 +1,28 @@
+package filtering
+
+import "fmt"
+
+// Position represents a position in a filter expression.
+type Position struct {
+	// Offset is the byte offset, starting at 0.
+	Offset int
+	// Line is the line number, starting at 1.
+	Line int
+	// Column is the column number, starting at 1 (character count per line).
+	Column int
+}
+
+// String returns a string representation of the position on the format <line>:<column>.
+func (p Position) String() string {
+	return fmt.Sprintf("%d:%d", p.Line, p.Column)
+}
+
+func (p *Position) advance(r rune, n int) {
+	p.Offset += n
+	if r == '\n' {
+		p.Line++
+		p.Column = 1
+	} else {
+		p.Column++
+	}
+}

--- a/filtering/token.go
+++ b/filtering/token.go
@@ -1,0 +1,11 @@
+package filtering
+
+// Token represents a token in a filter expression.
+type Token struct {
+	// Position of the token.
+	Position Position
+	// Type of the token.
+	Type TokenType
+	// Value of the token, if the token is a text or a string.
+	Value string
+}

--- a/filtering/tokentype.go
+++ b/filtering/tokentype.go
@@ -1,0 +1,37 @@
+package filtering
+
+// TokenType represents the type of a filter expression token.
+//
+// See: https://google.aip.dev/assets/misc/ebnf-filtering.txt
+type TokenType string
+
+// Value token types.
+const (
+	TokenTypeWhitespace TokenType = "WS"
+	TokenTypeText       TokenType = "TEXT"
+	TokenTypeString     TokenType = "STRING"
+)
+
+// Keyword token types.
+const (
+	TokenTypeNot TokenType = "NOT"
+	TokenTypeAnd TokenType = "AND"
+	TokenTypeOr  TokenType = "OR"
+)
+
+// Operator token types.
+const (
+	TokenTypeLeftParen     TokenType = "("
+	TokenTypeRightParen    TokenType = ")"
+	TokenTypeMinus         TokenType = "-"
+	TokenTypeDot           TokenType = "."
+	TokenTypeEquals        TokenType = "="
+	TokenTypeHas           TokenType = ":"
+	TokenTypeLess          TokenType = "<"
+	TokenTypeGreater       TokenType = ">"
+	TokenTypeExclaim       TokenType = "!"
+	TokenTypeComma         TokenType = ","
+	TokenTypeLessEquals    TokenType = "<="
+	TokenTypeGreaterEquals TokenType = ">="
+	TokenTypeNotEquals     TokenType = "!="
+)


### PR DESCRIPTION
Step one for implementing support for AIP request filters.

The lexer is built according to the EBNF grammar at:

https://google.aip.dev/assets/misc/ebnf-filtering.txt

...with the `!` operator as one small addition to simplify the lexer and
make operator parsing more consistent.

In the future, we may want to extend the lexer with native support for
numbers, as the grafeas parser has:

https://github.com/grafeas/grafeas/blob/7888ad45e6a5b687a279ac002c864ce073600da1/go/filtering/parser/gen/FilterExpression.g4#L121-L136
