### PR TITLE
feat: add validation methods to fieldmask and ordering packages

### DIFF
--- a/fieldmask/validate.go
+++ b/fieldmask/validate.go
@@ -1,0 +1,65 @@
+package fieldmask
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// Validate validates that the paths in the provided field mask are syntactically valid and
+// refer to known fields in the specified message type.
+func Validate(fm *fieldmaskpb.FieldMask, m proto.Message) error {
+	md0 := m.ProtoReflect().Descriptor()
+	for _, path := range fm.GetPaths() {
+		md := md0
+		if !rangeFields(path, func(field string) bool {
+			// Search the field within the message.
+			if md == nil {
+				return false // not within a message
+			}
+			fd := md.Fields().ByName(protoreflect.Name(field))
+			// The real field name of a group is the message name.
+			if fd == nil {
+				gd := md.Fields().ByName(protoreflect.Name(strings.ToLower(field)))
+				if gd != nil && gd.Kind() == protoreflect.GroupKind && string(gd.Message().Name()) == field {
+					fd = gd
+				}
+			} else if fd.Kind() == protoreflect.GroupKind && string(fd.Message().Name()) != field {
+				fd = nil
+			}
+			if fd == nil {
+				return false // message has does not have this field
+			}
+			// Identify the next message to search within.
+			md = fd.Message() // may be nil
+			if fd.IsMap() {
+				md = fd.MapValue().Message() // may be nil
+			}
+			return true
+		}) {
+			return fmt.Errorf("invalid field path: %s", path)
+		}
+	}
+	return nil
+}
+
+func rangeFields(path string, f func(field string) bool) bool {
+	for {
+		var field string
+		if i := strings.IndexByte(path, '.'); i >= 0 {
+			field, path = path[:i], path[i:]
+		} else {
+			field, path = path, ""
+		}
+		if !f(field) {
+			return false
+		}
+		if len(path) == 0 {
+			return true
+		}
+		path = strings.TrimPrefix(path, ".")
+	}
+}

--- a/fieldmask/validate_test.go
+++ b/fieldmask/validate_test.go
@@ -1,0 +1,70 @@
+package fieldmask
+
+import (
+	"testing"
+
+	"google.golang.org/genproto/googleapis/example/library/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"gotest.tools/v3/assert"
+)
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name          string
+		fieldMask     *fieldmaskpb.FieldMask
+		message       proto.Message
+		errorContains string
+	}{
+		{
+			name:      "valid empty",
+			fieldMask: &fieldmaskpb.FieldMask{},
+			message:   &library.Book{},
+		},
+
+		{
+			name: "valid single",
+			fieldMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"name", "author"},
+			},
+			message: &library.Book{},
+		},
+
+		{
+			name: "invalid single",
+			fieldMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"name", "foo"},
+			},
+			message:       &library.Book{},
+			errorContains: "invalid field path: foo",
+		},
+
+		{
+			name: "valid nested",
+			fieldMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"name", "book.name"},
+			},
+			message: &library.CreateBookRequest{},
+		},
+
+		{
+			name: "invalid nested",
+			fieldMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"name", "book.foo"},
+			},
+			message:       &library.CreateBookRequest{},
+			errorContains: "invalid field path: book.foo",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, Validate(tt.fieldMask, tt.message), tt.errorContains)
+			} else {
+				assert.NilError(t, Validate(tt.fieldMask, tt.message))
+			}
+		})
+	}
+}

--- a/ordering/orderby_test.go
+++ b/ordering/orderby_test.go
@@ -70,77 +70,6 @@ func TestOrderBy_UnmarshalString(t *testing.T) {
 	}
 }
 
-func TestOrderBy_IsValidForMessage(t *testing.T) {
-	t.Parallel()
-	for _, tt := range []struct {
-		name    string
-		orderBy OrderBy
-		message proto.Message
-		isValid bool
-	}{
-		{
-			name:    "valid empty",
-			orderBy: OrderBy{},
-			message: &library.Book{},
-			isValid: true,
-		},
-
-		{
-			name: "valid single",
-			orderBy: OrderBy{
-				Fields: []Field{
-					{Path: "name"},
-					{Path: "author"},
-				},
-			},
-			message: &library.Book{},
-			isValid: true,
-		},
-
-		{
-			name: "invalid single",
-			orderBy: OrderBy{
-				Fields: []Field{
-					{Path: "name"},
-					{Path: "foo"},
-				},
-			},
-			message: &library.Book{},
-			isValid: false,
-		},
-
-		{
-			name: "valid nested",
-			orderBy: OrderBy{
-				Fields: []Field{
-					{Path: "name"},
-					{Path: "book.name"},
-				},
-			},
-			message: &library.CreateBookRequest{},
-			isValid: true,
-		},
-
-		{
-			name: "invalid nested",
-			orderBy: OrderBy{
-				Fields: []Field{
-					{Path: "name"},
-					{Path: "book.foo"},
-				},
-			},
-			message: &library.CreateBookRequest{},
-			isValid: false,
-		},
-	} {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.isValid, tt.orderBy.IsValidForMessage(tt.message))
-		})
-	}
-}
-
 func TestOrderBy_ValidateForPaths(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
@@ -208,6 +137,78 @@ func TestOrderBy_ValidateForPaths(t *testing.T) {
 				assert.ErrorContains(t, tt.orderBy.ValidateForPaths(tt.paths...), tt.errorContains)
 			} else {
 				assert.NilError(t, tt.orderBy.ValidateForPaths(tt.paths...))
+			}
+		})
+	}
+}
+
+func TestOrderBy_ValidateForMessage(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name          string
+		orderBy       OrderBy
+		message       proto.Message
+		errorContains string
+	}{
+		{
+			name:    "valid empty",
+			orderBy: OrderBy{},
+			message: &library.Book{},
+		},
+
+		{
+			name: "valid single",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "author"},
+				},
+			},
+			message: &library.Book{},
+		},
+
+		{
+			name: "invalid single",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "foo"},
+				},
+			},
+			message:       &library.Book{},
+			errorContains: "invalid field path: foo",
+		},
+
+		{
+			name: "valid nested",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "book.name"},
+				},
+			},
+			message: &library.CreateBookRequest{},
+		},
+
+		{
+			name: "invalid nested",
+			orderBy: OrderBy{
+				Fields: []Field{
+					{Path: "name"},
+					{Path: "book.foo"},
+				},
+			},
+			message:       &library.CreateBookRequest{},
+			errorContains: "invalid field path: book.foo",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, tt.orderBy.ValidateForMessage(tt.message), tt.errorContains)
+			} else {
+				assert.NilError(t, tt.orderBy.ValidateForMessage(tt.message))
 			}
 		})
 	}


### PR DESCRIPTION
OrderBy.ValidateForMessage now returns an error message of which path is
invalid. It in turn uses fieldmask.ValidatePathsForMessage which
validates a given set of field mask paths for a message.

The shorthand fieldmask.ValidateForMessage is provided to be used for
field mask validation in Update standard methods.
