### PR TITLE
feat: add aipregistry.Resources

### DIFF
--- a/reflect/aipreflect/resourcedescriptor_test.go
+++ b/reflect/aipreflect/resourcedescriptor_test.go
@@ -1,0 +1,75 @@
+package aipreflect
+
+import (
+	"testing"
+
+	examplefreightv1 "go.einride.tech/aip/examples/proto/gen/einride/example/freight/v1"
+	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+	"gotest.tools/v3/assert"
+)
+
+func TestNewResourceDescriptor(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name          string
+		msg           proto.Message
+		expected      *ResourceDescriptor
+		errorContains string
+	}{
+		{
+			name: "einride.example.freight.v1.Shipper",
+			msg:  &examplefreightv1.Shipper{},
+			expected: &ResourceDescriptor{
+				Type: "freight-example.einride.tech/Shipper",
+				Names: []*ResourceNameDescriptor{
+					{
+						Type: "freight-example.einride.tech/Shipper",
+						Pattern: ResourceNamePatternDescriptor{
+							Segments: []ResourceNameSegmentDescriptor{
+								{Value: "shippers"},
+								{Value: "shipper", Variable: true},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "einride.example.freight.v1.Shipment",
+			msg:  &examplefreightv1.Shipment{},
+			expected: &ResourceDescriptor{
+				Type: "freight-example.einride.tech/Shipment",
+				Names: []*ResourceNameDescriptor{
+					{
+						Type: "freight-example.einride.tech/Shipment",
+						Pattern: ResourceNamePatternDescriptor{
+							Segments: []ResourceNameSegmentDescriptor{
+								{Value: "shippers"},
+								{Value: "shipper", Variable: true},
+								{Value: "shipments"},
+								{Value: "shipment", Variable: true},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			options := tt.msg.ProtoReflect().Descriptor().Options()
+			protoDesc := proto.GetExtension(options, annotations.E_Resource).(*annotations.ResourceDescriptor)
+			assert.Assert(t, protoDesc != nil)
+			actual, err := NewResourceDescriptor(protoDesc)
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+			} else {
+				assert.NilError(t, err)
+				assert.DeepEqual(t, tt.expected, actual)
+			}
+		})
+	}
+}

--- a/reflect/aipreflect/resourcenamedescriptor.go
+++ b/reflect/aipreflect/resourcenamedescriptor.go
@@ -2,9 +2,12 @@ package aipreflect
 
 // ResourceNameDescriptor describes a resource name.
 type ResourceNameDescriptor struct {
-	Resource *ResourceDescriptor
-	Parent   *ResourceDescriptor
-	Pattern  *ResourceNamePatternDescriptor
+	// Type is the resource type name of the resource name's resource type.
+	Type ResourceTypeName
+	// Ancestors are the resource type names of the resource name's ancestors.
+	Ancestors []ResourceTypeName
+	// Pattern describes the resource name's pattern.
+	Pattern ResourceNamePatternDescriptor
 }
 
 // NewResourceNameDescriptor returns a new resource name descriptor for the provided pattern.

--- a/reflect/aipreflect/resourcenamedescriptor_test.go
+++ b/reflect/aipreflect/resourcenamedescriptor_test.go
@@ -1,0 +1,54 @@
+package aipreflect
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestNewResourceNameDescriptor(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		pattern       string
+		expected      *ResourceNameDescriptor
+		errorContains string
+	}{
+		{
+			pattern: "shippers/{shipper}",
+			expected: &ResourceNameDescriptor{
+				Pattern: ResourceNamePatternDescriptor{
+					Segments: []ResourceNameSegmentDescriptor{
+						{Value: "shippers"},
+						{Value: "shipper", Variable: true},
+					},
+				},
+			},
+		},
+
+		{
+			pattern: "shippers/{shipper}/shipments/{shipment}",
+			expected: &ResourceNameDescriptor{
+				Pattern: ResourceNamePatternDescriptor{
+					Segments: []ResourceNameSegmentDescriptor{
+						{Value: "shippers"},
+						{Value: "shipper", Variable: true},
+						{Value: "shipments"},
+						{Value: "shipment", Variable: true},
+					},
+				},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.pattern, func(t *testing.T) {
+			t.Parallel()
+			actual, err := NewResourceNameDescriptor(tt.pattern)
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+			} else {
+				assert.NilError(t, err)
+				assert.DeepEqual(t, tt.expected, actual)
+			}
+		})
+	}
+}

--- a/reflect/aipreflect/resourcenamepatterndescriptor_test.go
+++ b/reflect/aipreflect/resourcenamepatterndescriptor_test.go
@@ -140,3 +140,66 @@ func TestResourceNamePatternDescriptor_ValidateResourceName(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceNamePatternDescriptor_Ancestors(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		pattern  string
+		expected []ResourceNamePatternDescriptor
+	}{
+		{
+			name:     "top-level",
+			pattern:  "publishers/{publisher}",
+			expected: nil,
+		},
+
+		{
+			name:     "top-level, singleton",
+			pattern:  "singleton",
+			expected: nil,
+		},
+
+		{
+			name:    "child",
+			pattern: "publishers/{publisher}/books/{book}",
+			expected: []ResourceNamePatternDescriptor{
+				{
+					Segments: []ResourceNameSegmentDescriptor{
+						{Value: "publishers"},
+						{Value: "publisher", Variable: true},
+					},
+				},
+			},
+		},
+
+		{
+			name:    "child, singleton",
+			pattern: "publishers/{publisher}/books/{book}/options",
+			expected: []ResourceNamePatternDescriptor{
+				{
+					Segments: []ResourceNameSegmentDescriptor{
+						{Value: "publishers"},
+						{Value: "publisher", Variable: true},
+						{Value: "books"},
+						{Value: "book", Variable: true},
+					},
+				},
+				{
+					Segments: []ResourceNameSegmentDescriptor{
+						{Value: "publishers"},
+						{Value: "publisher", Variable: true},
+					},
+				},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pattern, err := NewResourceNamePatternDescriptor(tt.pattern)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, tt.expected, pattern.Ancestors())
+		})
+	}
+}

--- a/reflect/aipreflect/resourcetypedescriptor_test.go
+++ b/reflect/aipreflect/resourcetypedescriptor_test.go
@@ -6,16 +6,6 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestResourceTypeDescriptor(t *testing.T) {
-	t.Parallel()
-	t.Run("can be used as map key", func(t *testing.T) {
-		t.Parallel()
-		m := map[ResourceTypeDescriptor]string{}
-		m[ResourceTypeDescriptor{ServiceName: "pubsub.googleapis.com", Type: "Topic"}] = "test"
-		assert.Equal(t, "test", m[ResourceTypeDescriptor{ServiceName: "pubsub.googleapis.com", Type: "Topic"}])
-	})
-}
-
 func TestResourceTypeDescriptor_String(t *testing.T) {
 	t.Parallel()
 	const expected = "pubsub.googleapis.com/Topic"

--- a/reflect/aipreflect/resourcetypename.go
+++ b/reflect/aipreflect/resourcetypename.go
@@ -1,0 +1,66 @@
+package aipreflect
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// ResourceTypeName represents a resource type name.
+type ResourceTypeName string // e.g. pubsub.googleapis.com/Topic.
+
+// Validate checks that the resource type name is syntactically valid.
+func (n ResourceTypeName) Validate() error {
+	if strings.Count(string(n), "/") != 1 {
+		return fmt.Errorf("validate resource type name '%s': invalid format", n)
+	}
+	if err := validateServiceName(n.ServiceName()); err != nil {
+		return fmt.Errorf("validate resource type name '%s': %w", n, err)
+	}
+	if err := validateType(n.Type()); err != nil {
+		return fmt.Errorf("validate resource type name '%s': %w", n, err)
+	}
+	return nil
+}
+
+// ServiceName returns the service name of the resource type name.
+func (n ResourceTypeName) ServiceName() string {
+	if i := strings.LastIndexByte(string(n), '/'); i >= 0 {
+		return string(n[:i])
+	}
+	return ""
+}
+
+// Type returns the type of the resource type name.
+func (n ResourceTypeName) Type() string {
+	if i := strings.LastIndexByte(string(n), '/'); i >= 0 {
+		return string(n[i+1:])
+	}
+	return ""
+}
+
+func validateServiceName(serviceName string) error {
+	if serviceName == "" {
+		return fmt.Errorf("service name: empty")
+	}
+	if !strings.ContainsRune(serviceName, '.') {
+		return fmt.Errorf("service name: must be a valid domain name")
+	}
+	return nil
+}
+
+func validateType(t string) error {
+	if t == "" {
+		return fmt.Errorf("type: is empty")
+	}
+	if firstRune, _ := utf8.DecodeRuneInString(t); !unicode.IsUpper(firstRune) {
+		return fmt.Errorf("type: must start with an upper-case letter")
+	}
+	for _, r := range t {
+		if !unicode.In(r, unicode.Letter, unicode.Digit) {
+			return fmt.Errorf("type: must be UpperCamelCase")
+		}
+	}
+	return nil
+}

--- a/reflect/aipreflect/resourcetypename_test.go
+++ b/reflect/aipreflect/resourcetypename_test.go
@@ -1,0 +1,41 @@
+package aipreflect
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestResourceTypeName_Validate(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name          string
+		errorContains string
+	}{
+		{
+			name: "pubsub.googleapis.com/Topic",
+		},
+		{
+			name:          "pubsub/Topic",
+			errorContains: "service name: must be a valid domain name",
+		},
+		{
+			name:          "pubsub.googleapis.com/topic",
+			errorContains: "type: must start with an upper-case letter",
+		},
+		{
+			name:          "pubsub.googleapis.com/Topic_2",
+			errorContains: "type: must be UpperCamelCase",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, ResourceTypeName(tt.name).Validate(), tt.errorContains)
+			} else {
+				assert.NilError(t, ResourceTypeName(tt.name).Validate())
+			}
+		})
+	}
+}

--- a/reflect/aipregistry/resources.go
+++ b/reflect/aipregistry/resources.go
@@ -1,0 +1,151 @@
+package aipregistry
+
+import (
+	"fmt"
+
+	"go.einride.tech/aip/reflect/aipreflect"
+	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// Resources is a registry of resource descriptors and their relationships.
+type Resources struct {
+	resourcesByType         map[aipreflect.ResourceTypeName]*aipreflect.ResourceDescriptor
+	resourcesByWildcardName map[string]*aipreflect.ResourceDescriptor
+}
+
+// NewResources creates a new resource registry from the provided file registry.
+// The file registry is used to resolve parent / child relationships and to find standard methods.
+func NewResources(files *protoregistry.Files) (*Resources, error) {
+	registry := &Resources{
+		resourcesByType:         make(map[aipreflect.ResourceTypeName]*aipreflect.ResourceDescriptor, files.NumFiles()),
+		resourcesByWildcardName: make(map[string]*aipreflect.ResourceDescriptor, files.NumFiles()),
+	}
+	var responseErr error
+	files.RangeFiles(func(file protoreflect.FileDescriptor) bool {
+		if err := registry.registerFile(file); err != nil {
+			responseErr = err
+			return false
+		}
+		return true
+	})
+	if responseErr != nil {
+		return nil, responseErr
+	}
+	registry.updateAncestries()
+	return registry, nil
+}
+
+// FindDescriptorByName looks up a resource descriptor by the type name.
+func (r *Resources) FindResourceByType(t aipreflect.ResourceTypeName) (*aipreflect.ResourceDescriptor, bool) {
+	resource, ok := r.resourcesByType[t]
+	return resource, ok
+}
+
+// RangeResources iterates over all registered resources while f returns true.
+// The iteration order is undefined.
+func (r *Resources) RangeResources(f func(*aipreflect.ResourceDescriptor) bool) {
+	if r == nil {
+		return
+	}
+	for _, resource := range r.resourcesByType {
+		if !f(resource) {
+			return
+		}
+	}
+}
+
+func (r *Resources) updateAncestries() {
+	for _, resource := range r.resourcesByType {
+		for _, name := range resource.Names {
+			ancestorPatterns := name.Pattern.Ancestors()
+			if len(ancestorPatterns) > 0 {
+				name.Ancestors = make([]aipreflect.ResourceTypeName, 0, len(ancestorPatterns))
+			}
+			for _, ancestorPattern := range ancestorPatterns {
+				ancestor, ok := r.resourcesByWildcardName[ancestorPattern.Wildcard()]
+				if !ok {
+					continue
+				}
+				ancestorResourceType := ancestor.Type
+				name.Ancestors = append(name.Ancestors, ancestorResourceType)
+			}
+		}
+	}
+}
+
+func (r *Resources) registerFile(file protoreflect.FileDescriptor) (err error) {
+	descriptors := proto.GetExtension(file.Options(), annotations.E_ResourceDefinition)
+	for _, descriptor := range descriptors.([]*annotations.ResourceDescriptor) {
+		resource, err := aipreflect.NewResourceDescriptor(descriptor)
+		if err != nil {
+			return fmt.Errorf("register %s: %w", file.FullName(), err)
+		}
+		resource.ParentFile = file.Path()
+		if err := r.registerResource(resource); err != nil {
+			return fmt.Errorf("register %s: %w", file.FullName(), err)
+		}
+	}
+	for i := 0; i < file.Messages().Len(); i++ {
+		if err := r.registerMessage(file.Messages().Get(i)); err != nil {
+			return fmt.Errorf("register %s: %w", file.FullName(), err)
+		}
+	}
+	return nil
+}
+
+func (r *Resources) registerMessage(message protoreflect.MessageDescriptor) (err error) {
+	descriptor := proto.GetExtension(message.Options(), annotations.E_Resource).(*annotations.ResourceDescriptor)
+	if descriptor == nil {
+		return fmt.Errorf("register %s: %w", message.FullName(), err)
+	}
+	resource, err := aipreflect.NewResourceDescriptor(descriptor)
+	if err != nil {
+		return fmt.Errorf("register %s: %w", message.FullName(), err)
+	}
+	resource.ParentFile = message.ParentFile().Path()
+	resource.Message = message.FullName()
+	if err := r.registerResource(resource); err != nil {
+		return fmt.Errorf("register %s: %w", message.FullName(), err)
+	}
+	return nil
+}
+
+func (r *Resources) registerResource(resource *aipreflect.ResourceDescriptor) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("register %s: %w", resource.Type, err)
+		}
+	}()
+	if existingResource, ok := r.FindResourceByType(resource.Type); ok {
+		switch {
+		case resource.Message != "" && existingResource.Message != "":
+			return fmt.Errorf(
+				"conflict registering resource %s from message %s: already registered to message %s",
+				resource.Type,
+				resource.Message,
+				existingResource.Message,
+			)
+		case resource.Message == "" && existingResource.Message != "":
+			return nil // ignore file declarations when we already have the full message resource descriptor
+		case resource.Message != "" && existingResource.Message == "":
+			break // overwrite resource descriptors from file declarations with the full message descriptor
+		case resource.Message == "" && existingResource.Message == "":
+			if len(resource.Names) != len(existingResource.Names) {
+				return fmt.Errorf(
+					"conflict registering resource %s from file %s: file %s has registered with other resource names",
+					resource.Type,
+					resource.ParentFile,
+					existingResource.ParentFile,
+				)
+			}
+		}
+	}
+	r.resourcesByType[resource.Type] = resource
+	for _, name := range resource.Names {
+		r.resourcesByWildcardName[name.Pattern.Wildcard()] = resource
+	}
+	return nil
+}

--- a/reflect/aipregistry/resources_test.go
+++ b/reflect/aipregistry/resources_test.go
@@ -1,0 +1,108 @@
+package aipregistry
+
+import (
+	"testing"
+
+	examplefreightv1 "go.einride.tech/aip/examples/proto/gen/einride/example/freight/v1"
+	"go.einride.tech/aip/reflect/aipreflect"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"gotest.tools/v3/assert"
+)
+
+func TestNewResources(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		files    []protoreflect.FileDescriptor
+		expected map[aipreflect.ResourceTypeName]*aipreflect.ResourceDescriptor
+	}{
+		{
+			name: "einride.example.freight.v1",
+			files: []protoreflect.FileDescriptor{
+				examplefreightv1.File_einride_example_freight_v1_shipper_proto,
+				examplefreightv1.File_einride_example_freight_v1_site_proto,
+				examplefreightv1.File_einride_example_freight_v1_shipment_proto,
+			},
+			expected: map[aipreflect.ResourceTypeName]*aipreflect.ResourceDescriptor{
+				"freight-example.einride.tech/Shipper": {
+					ParentFile: "einride/example/freight/v1/shipper.proto",
+					Message:    "einride.example.freight.v1.Shipper",
+					Type:       "freight-example.einride.tech/Shipper",
+					Names: []*aipreflect.ResourceNameDescriptor{
+						{
+							Type: "freight-example.einride.tech/Shipper",
+							Pattern: aipreflect.ResourceNamePatternDescriptor{
+								Segments: []aipreflect.ResourceNameSegmentDescriptor{
+									{Value: "shippers"},
+									{Value: "shipper", Variable: true},
+								},
+							},
+						},
+					},
+				},
+
+				"freight-example.einride.tech/Shipment": {
+					ParentFile: "einride/example/freight/v1/shipment.proto",
+					Message:    "einride.example.freight.v1.Shipment",
+					Type:       "freight-example.einride.tech/Shipment",
+					Names: []*aipreflect.ResourceNameDescriptor{
+						{
+							Type: "freight-example.einride.tech/Shipment",
+							Ancestors: []aipreflect.ResourceTypeName{
+								"freight-example.einride.tech/Shipper",
+							},
+							Pattern: aipreflect.ResourceNamePatternDescriptor{
+								Segments: []aipreflect.ResourceNameSegmentDescriptor{
+									{Value: "shippers"},
+									{Value: "shipper", Variable: true},
+									{Value: "shipments"},
+									{Value: "shipment", Variable: true},
+								},
+							},
+						},
+					},
+				},
+
+				"freight-example.einride.tech/Site": {
+					ParentFile: "einride/example/freight/v1/site.proto",
+					Message:    "einride.example.freight.v1.Site",
+					Type:       "freight-example.einride.tech/Site",
+					Names: []*aipreflect.ResourceNameDescriptor{
+						{
+							Type: "freight-example.einride.tech/Site",
+							Ancestors: []aipreflect.ResourceTypeName{
+								"freight-example.einride.tech/Shipper",
+							},
+							Pattern: aipreflect.ResourceNamePatternDescriptor{
+								Segments: []aipreflect.ResourceNameSegmentDescriptor{
+									{Value: "shippers"},
+									{Value: "shipper", Variable: true},
+									{Value: "sites"},
+									{Value: "site", Variable: true},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var files protoregistry.Files
+			for _, file := range tt.files {
+				assert.NilError(t, files.RegisterFile(file))
+			}
+			resources, err := NewResources(&files)
+			assert.NilError(t, err)
+			actual := map[aipreflect.ResourceTypeName]*aipreflect.ResourceDescriptor{}
+			resources.RangeResources(func(resource *aipreflect.ResourceDescriptor) bool {
+				actual[resource.Type] = resource
+				return true
+			})
+			assert.DeepEqual(t, tt.expected, actual)
+		})
+	}
+}

--- a/tools/golangci-lint/rules.mk
+++ b/tools/golangci-lint/rules.mk
@@ -1,5 +1,5 @@
 golangci_lint_cwd := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-golangci_lint_version := 1.33.0
+golangci_lint_version := 1.34.1
 golangci_lint := $(golangci_lint_cwd)/$(golangci_lint_version)/golangci-lint
 
 ifeq ($(shell uname),Linux)


### PR DESCRIPTION
Given a protoregistry.Files, aipregistry.Resources parses all resource
descriptors and resolves all resource ancestries.

To be used for both runtime reflection and code generation.
