### PR TITLE
feat: add ResourceDescriptor.InferMethodName

### DIFF
--- a/reflect/aipreflect/grammaticalname.go
+++ b/reflect/aipreflect/grammaticalname.go
@@ -1,0 +1,32 @@
+package aipreflect
+
+import (
+	"fmt"
+	"unicode"
+	"unicode/utf8"
+)
+
+// GrammaticalName is the grammatical name for the singular or plural form of resource resource type.
+// Grammatical names must be URL-safe and use lowerCamelCase.
+type GrammaticalName string // e.g. "userEvents"
+
+// Validate checks that the grammatical name is non-empty, URL-safe, and uses lowerCamelCase.
+func (g GrammaticalName) Validate() error {
+	if len(g) == 0 {
+		return fmt.Errorf("validate grammatical name: must be non-empty")
+	}
+	for _, r := range g {
+		if !unicode.In(r, unicode.Letter, unicode.Digit) {
+			return fmt.Errorf("validate grammatical name '%s': contains forbidden character '%s'", g, string(r))
+		}
+	}
+	if r, _ := utf8.DecodeRuneInString(string(g)); !unicode.IsLower(r) {
+		return fmt.Errorf("validate grammatical name '%s': must be lowerCamelCase", g)
+	}
+	return nil
+}
+
+// UpperCamelCase returns the UpperCamelCase version of the grammatical name, for use in e.g. method names.
+func (g GrammaticalName) UpperCamelCase() string {
+	return initialUpperCase(string(g))
+}

--- a/reflect/aipreflect/grammaticalname_test.go
+++ b/reflect/aipreflect/grammaticalname_test.go
@@ -1,0 +1,32 @@
+package aipreflect
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGrammaticalName_Validate(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name          string
+		errorContains string
+	}{
+		{name: "", errorContains: "must be non-empty"},
+		{name: "users"},
+		{name: "userEvents"},
+		{name: "UserEvents", errorContains: "must be lowerCamelCase"},
+		{name: "user events", errorContains: "contains forbidden character ' '"},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := GrammaticalName(tt.name).Validate()
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}

--- a/reflect/aipreflect/methodtype.go
+++ b/reflect/aipreflect/methodtype.go
@@ -1,0 +1,70 @@
+package aipreflect
+
+// MethodType is an AIP method type.
+type MethodType string
+
+const (
+	// MethodTypeGet is the method type of the AIP standard Get method.
+	// See: https://google.aip.dev/131 (Standard methods: Get).
+	MethodTypeGet MethodType = "Get"
+
+	// MethodTypeList is the method type of the AIP standard List method.
+	// See: https://google.aip.dev/132 (Standard methods: List).
+	MethodTypeList MethodType = "List"
+
+	// MethodTypeCreate is the method type of the AIP standard Create method.
+	// See: https://google.aip.dev/133 (Standard methods: Create).
+	MethodTypeCreate MethodType = "Create"
+
+	// MethodTypeUpdate is the method type of the AIP standard Update method.
+	// See: https://google.aip.dev/133 (Standard methods: Update).
+	MethodTypeUpdate MethodType = "Update"
+
+	// MethodTypeDelete is the method type of the AIP standard Delete method.
+	// See: https://google.aip.dev/135 (Standard methods: Delete).
+	MethodTypeDelete MethodType = "Delete"
+
+	// MethodTypeSearch is the method type of the custom AIP method for searching a resource collection.
+	// See: https://google.aip.dev/136 (Custom methods).
+	MethodTypeSearch MethodType = "Search"
+
+	// MethodTypeUndelete is the method type of the AIP Undelete method for soft delete.
+	// See: https://google.aip.dev/164 (Soft delete).
+	MethodTypeUndelete MethodType = "Undelete"
+
+	// MethodTypeBatchGet is the method type of the AIP standard BatchGet method.
+	// See: https://google.aip.dev/231 (Batch methods: Get).
+	MethodTypeBatchGet MethodType = "BatchGet"
+
+	// MethodTypeBatchCreate is the method type of the AIP standard BatchCreate method.
+	// See: https://google.aip.dev/233 (Batch methods: Create).
+	MethodTypeBatchCreate MethodType = "BatchCreate"
+
+	// MethodTypeBatchUpdate is the method type of the AIP standard BatchUpdate method.
+	// See: https://google.aip.dev/234 (Batch methods: Update).
+	MethodTypeBatchUpdate MethodType = "BatchUpdate"
+
+	// MethodTypeBatchDelete is the method type of the AIP standard BatchDelete method.
+	// See: https://google.aip.dev/235 (Batch methods: Delete).
+	MethodTypeBatchDelete MethodType = "BatchDelete"
+)
+
+// IsPlural returns true if the method type relates to a plurality of resources.
+func (s MethodType) IsPlural() bool {
+	switch s {
+	case MethodTypeList,
+		MethodTypeSearch,
+		MethodTypeBatchGet,
+		MethodTypeBatchCreate,
+		MethodTypeBatchUpdate,
+		MethodTypeBatchDelete:
+		return true
+	case MethodTypeCreate,
+		MethodTypeDelete,
+		MethodTypeGet,
+		MethodTypeUndelete,
+		MethodTypeUpdate:
+		return false
+	}
+	return false
+}

--- a/reflect/aipreflect/methodtype_test.go
+++ b/reflect/aipreflect/methodtype_test.go
@@ -1,0 +1,30 @@
+package aipreflect
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestMethodType_IsPlural(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		methodType MethodType
+		expected   bool
+	}{
+		{methodType: MethodTypeGet, expected: false},
+		{methodType: MethodTypeCreate, expected: false},
+		{methodType: MethodTypeDelete, expected: false},
+		{methodType: MethodTypeGet, expected: false},
+		{methodType: MethodTypeUndelete, expected: false},
+		{methodType: MethodTypeUpdate, expected: false},
+		{methodType: MethodTypeList, expected: true},
+		{methodType: MethodTypeSearch, expected: true},
+		{methodType: MethodTypeBatchGet, expected: true},
+		{methodType: MethodTypeBatchCreate, expected: true},
+		{methodType: MethodTypeBatchUpdate, expected: true},
+		{methodType: MethodTypeBatchDelete, expected: true},
+	} {
+		assert.Assert(t, tt.methodType.IsPlural() == tt.expected, tt.methodType)
+	}
+}

--- a/reflect/aipreflect/resourcedescriptor_test.go
+++ b/reflect/aipreflect/resourcedescriptor_test.go
@@ -6,6 +6,7 @@ import (
 	examplefreightv1 "go.einride.tech/aip/examples/proto/gen/einride/example/freight/v1"
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"gotest.tools/v3/assert"
 )
 
@@ -33,6 +34,8 @@ func TestNewResourceDescriptor(t *testing.T) {
 						},
 					},
 				},
+				Singular: "shipper",
+				Plural:   "shippers",
 			},
 		},
 
@@ -54,6 +57,8 @@ func TestNewResourceDescriptor(t *testing.T) {
 						},
 					},
 				},
+				Singular: "shipment",
+				Plural:   "shipments",
 			},
 		},
 	} {
@@ -69,6 +74,68 @@ func TestNewResourceDescriptor(t *testing.T) {
 			} else {
 				assert.NilError(t, err)
 				assert.DeepEqual(t, tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestResourceDescriptor_InferMethodName(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name          string
+		resource      *ResourceDescriptor
+		methodType    MethodType
+		expected      protoreflect.Name
+		errorContains string
+	}{
+		{
+			name: "get",
+			resource: &ResourceDescriptor{
+				Singular: "userEvent",
+				Plural:   "userEvents",
+			},
+			methodType: MethodTypeGet,
+			expected:   "GetUserEvent",
+		},
+
+		{
+			name: "list",
+			resource: &ResourceDescriptor{
+				Singular: "yellowSubmarine",
+				Plural:   "yellowSubmarines",
+			},
+			methodType: MethodTypeList,
+			expected:   "ListYellowSubmarines",
+		},
+
+		{
+			name: "missing singular",
+			resource: &ResourceDescriptor{
+				Plural: "userEvents",
+			},
+			methodType:    MethodTypeGet,
+			errorContains: "singular not specified",
+		},
+
+		{
+			name: "missing plural",
+			resource: &ResourceDescriptor{
+				Singular: "userEvent",
+			},
+			methodType:    MethodTypeList,
+			errorContains: "plural not specified",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual, err := tt.resource.InferMethodName(tt.methodType)
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+				assert.Equal(t, protoreflect.Name(""), actual)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, tt.expected, actual)
 			}
 		})
 	}

--- a/reflect/aipreflect/strcase.go
+++ b/reflect/aipreflect/strcase.go
@@ -1,0 +1,14 @@
+package aipreflect
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+func initialUpperCase(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	r, n := utf8.DecodeRuneInString(s)
+	return string(unicode.ToUpper(r)) + s[n:]
+}

--- a/reflect/aipreflect/strcase_test.go
+++ b/reflect/aipreflect/strcase_test.go
@@ -1,0 +1,25 @@
+package aipreflect
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func Test_initialUpperCase(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		s        string
+		expected string
+	}{
+		{s: "", expected: ""},
+		{s: "a", expected: "A"},
+		{s: "aaa", expected: "Aaa"},
+	} {
+		tt := tt
+		t.Run(tt.s, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, initialUpperCase(tt.s))
+		})
+	}
+}

--- a/reflect/aipregistry/resources_test.go
+++ b/reflect/aipregistry/resources_test.go
@@ -40,6 +40,8 @@ func TestNewResources(t *testing.T) {
 							},
 						},
 					},
+					Singular: "shipper",
+					Plural:   "shippers",
 				},
 
 				"freight-example.einride.tech/Shipment": {
@@ -62,6 +64,8 @@ func TestNewResources(t *testing.T) {
 							},
 						},
 					},
+					Singular: "shipment",
+					Plural:   "shipments",
 				},
 
 				"freight-example.einride.tech/Site": {
@@ -84,6 +88,8 @@ func TestNewResources(t *testing.T) {
 							},
 						},
 					},
+					Singular: "site",
+					Plural:   "sites",
 				},
 			},
 		},


### PR DESCRIPTION
Method name inference uses the grammatical names (singular/plural) of
the resource, in combination with a method type enum for known method
types.
