### PR TITLE
feat: add resourceid.NewSystemGeneratedBase32()

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ $ go get -u go.einride.tech/aip
 
 ### [AIP-132][aip-132] (Standard method: List)
 
-- Use [`pagination.OffsetPageToken`][offset] to implement offset-based
+- Use [`pagination.PageToken`][pagetoken] to implement offset-based
   pagination.
 
 [aip-132]: https://google.aip.dev/132
-[offset]: ./pagination/offsetpagetoken.go
+[pagetoken]: ./pagination/pagetoken.go
 
 ```go
 package examplelibrary
@@ -53,8 +53,8 @@ func (s *Server) ListShelves(
 	case request.PageSize > maxPageSize:
 		request.PageSize = maxPageSize
 	}
-	// Use pagination.OffsetPageToken for offset-based page tokens.
-	pageToken, err := pagination.ParseOffsetPageToken(request)
+	// Use pagination.PageToken for offset-based page tokens.
+	pageToken, err := pagination.ParsePageToken(request)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid page token")
 	}

--- a/examples/examplelibrary/listshelves.go
+++ b/examples/examplelibrary/listshelves.go
@@ -26,8 +26,8 @@ func (s *Server) ListShelves(
 	case request.PageSize > maxPageSize:
 		request.PageSize = maxPageSize
 	}
-	// Use pagination.OffsetPageToken for offset-based page tokens.
-	pageToken, err := pagination.ParseOffsetPageToken(request)
+	// Use pagination.PageToken for offset-based page tokens.
+	pageToken, err := pagination.ParsePageToken(request)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid page token")
 	}

--- a/examples/examplelibrary/listshelves_test.go
+++ b/examples/examplelibrary/listshelves_test.go
@@ -42,6 +42,6 @@ func ExampleServer_ListShelves() {
 	// Output:
 	// shelves/0001 Sci-Fi
 	// shelves/0002 Horror
-	// PP-BAwEBD09mZnNldFBhZ2VUb2tlbgH_ggABAgEGT2Zmc2V0AQQAAQ9SZXF1ZXN0Q2hlY2tzdW0BBgAAAAv_ggEEAfyaywRCAA==
+	// Nv-BAwEBCVBhZ2VUb2tlbgH_ggABAgEGT2Zmc2V0AQQAAQ9SZXF1ZXN0Q2hlY2tzdW0BBgAAAAv_ggEEAfyaywRCAA==
 	// shelves/0003 Romance
 }

--- a/pagination/pagetoken_test.go
+++ b/pagination/pagetoken_test.go
@@ -15,14 +15,14 @@ func TestParseOffsetPageToken(t *testing.T) {
 			Name:     "shelves/1",
 			PageSize: 10,
 		}
-		pageToken1, err := ParseOffsetPageToken(request1)
+		pageToken1, err := ParsePageToken(request1)
 		assert.NilError(t, err)
 		request2 := &library.ListBooksRequest{
 			Name:      "shelves/1",
 			PageSize:  20,
 			PageToken: pageToken1.Next(request1).String(),
 		}
-		pageToken2, err := ParseOffsetPageToken(request2)
+		pageToken2, err := ParsePageToken(request2)
 		assert.NilError(t, err)
 		assert.Equal(t, int64(10), pageToken2.Offset)
 		request3 := &library.ListBooksRequest{
@@ -30,7 +30,7 @@ func TestParseOffsetPageToken(t *testing.T) {
 			PageSize:  30,
 			PageToken: pageToken2.Next(request2).String(),
 		}
-		pageToken3, err := ParseOffsetPageToken(request3)
+		pageToken3, err := ParsePageToken(request3)
 		assert.NilError(t, err)
 		assert.Equal(t, int64(30), pageToken3.Offset)
 	})
@@ -42,9 +42,9 @@ func TestParseOffsetPageToken(t *testing.T) {
 			PageSize:  10,
 			PageToken: "invalid",
 		}
-		pageToken1, err := ParseOffsetPageToken(request)
+		pageToken1, err := ParsePageToken(request)
 		assert.ErrorContains(t, err, "decode")
-		assert.Equal(t, OffsetPageToken{}, pageToken1)
+		assert.Equal(t, PageToken{}, pageToken1)
 	})
 
 	t.Run("invalid checksum", func(t *testing.T) {
@@ -52,13 +52,13 @@ func TestParseOffsetPageToken(t *testing.T) {
 		request := &library.ListBooksRequest{
 			Name:     "shelves/1",
 			PageSize: 10,
-			PageToken: gobEncode(&OffsetPageToken{
+			PageToken: gobEncode(&PageToken{
 				Offset:          100,
 				RequestChecksum: 1234, // invalid
 			}),
 		}
-		pageToken1, err := ParseOffsetPageToken(request)
+		pageToken1, err := ParsePageToken(request)
 		assert.ErrorContains(t, err, "checksum")
-		assert.Equal(t, OffsetPageToken{}, pageToken1)
+		assert.Equal(t, PageToken{}, pageToken1)
 	})
 }

--- a/resourceid/systemgenerated.go
+++ b/resourceid/systemgenerated.go
@@ -1,8 +1,21 @@
 package resourceid
 
-import "github.com/google/uuid"
+import (
+	"encoding/base32"
+
+	"github.com/google/uuid"
+)
+
+// nolint: gochecknoglobals
+var base32Encoding = base32.NewEncoding("abcdefghijklmnopqrstuvwxyz234567").WithPadding(base32.NoPadding)
 
 // NewSystemGenerated returns a new system-generated resource ID.
 func NewSystemGenerated() string {
 	return uuid.New().String()
+}
+
+// NewSystemGenerated returns a new system-generated resource ID encoded as base32 lowercase.
+func NewSystemGeneratedBase32() string {
+	id := uuid.New()
+	return base32Encoding.EncodeToString(id[:])
 }

--- a/resourceid/systemgenerated_test.go
+++ b/resourceid/systemgenerated_test.go
@@ -13,3 +13,9 @@ func TestNewSystemGenerated(t *testing.T) {
 	const uuidV4Regexp = `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`
 	assert.Assert(t, cmp.Regexp(regexp.MustCompile(uuidV4Regexp), NewSystemGenerated()))
 }
+
+func TestNewSystemGeneratedBase32(t *testing.T) {
+	t.Parallel()
+	const base32Regexp = `^[a-z2-7]{26}$`
+	assert.Assert(t, cmp.Regexp(regexp.MustCompile(base32Regexp), NewSystemGeneratedBase32()))
+}


### PR DESCRIPTION
Semantically equivalent to a UUIDv4 but with a more compact, yet still
readable encoding.
