### PR TITLE
feat(pagination): expose Gob transcoding

### DIFF
--- a/pagination/pagetoken.go
+++ b/pagination/pagetoken.go
@@ -38,7 +38,7 @@ func ParsePageToken(request Request) (_ PageToken, err error) {
 		}, nil
 	}
 	var pageToken PageToken
-	if err := gobDecode(request.GetPageToken(), &pageToken); err != nil {
+	if err := DecodePageTokenStruct(request.GetPageToken(), &pageToken); err != nil {
 		return PageToken{}, err
 	}
 	if pageToken.RequestChecksum != requestChecksum {
@@ -57,5 +57,5 @@ func (p PageToken) Next(request Request) PageToken {
 
 // String returns a string representation of the page token.
 func (p PageToken) String() string {
-	return gobEncode(&p)
+	return EncodePageTokenStruct(&p)
 }

--- a/pagination/pagetoken_test.go
+++ b/pagination/pagetoken_test.go
@@ -52,7 +52,7 @@ func TestParseOffsetPageToken(t *testing.T) {
 		request := &library.ListBooksRequest{
 			Name:     "shelves/1",
 			PageSize: 10,
-			PageToken: gobEncode(&PageToken{
+			PageToken: EncodePageTokenStruct(&PageToken{
 				Offset:          100,
 				RequestChecksum: 1234, // invalid
 			}),

--- a/pagination/struct.go
+++ b/pagination/struct.go
@@ -9,7 +9,8 @@ import (
 	"strings"
 )
 
-func gobEncode(v interface{}) string {
+// EncodePageTokenStruct encodes an arbitrary struct as a page token.
+func EncodePageTokenStruct(v interface{}) string {
 	var b strings.Builder
 	base64Encoder := base64.NewEncoder(base64.URLEncoding, &b)
 	gobEncoder := gob.NewEncoder(base64Encoder)
@@ -18,10 +19,11 @@ func gobEncode(v interface{}) string {
 	return b.String()
 }
 
-func gobDecode(s string, v interface{}) error {
+// DecodePageTokenStruct decodes an encoded page token into an arbitrary struct.
+func DecodePageTokenStruct(s string, v interface{}) error {
 	dec := gob.NewDecoder(base64.NewDecoder(base64.URLEncoding, strings.NewReader(s)))
 	if err := dec.Decode(v); err != nil && !errors.Is(err, io.EOF) {
-		return fmt.Errorf("gob decode: %w", err)
+		return fmt.Errorf("decode page token struct: %w", err)
 	}
 	return nil
 }

--- a/pagination/struct_test.go
+++ b/pagination/struct_test.go
@@ -1,0 +1,37 @@
+package pagination
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestEncodePageTokenStruct(t *testing.T) {
+	t.Parallel()
+	const expected = "Kv-BAwEBCXBhZ2VUb2tlbgH_ggABAgEDSW50AQQAAQZTdHJpbmcBDAAAAAr_ggFUAQNmb28A"
+	type pageToken struct {
+		Int    int
+		String string
+	}
+	token := pageToken{
+		Int:    42,
+		String: "foo",
+	}
+	assert.Equal(t, expected, EncodePageTokenStruct(&token))
+}
+
+func TestDecodePageTokenStruct(t *testing.T) {
+	t.Parallel()
+	type pageToken struct {
+		Int    int
+		String string
+	}
+	var actual pageToken
+	const input = "Kv-BAwEBCXBhZ2VUb2tlbgH_ggABAgEDSW50AQQAAQZTdHJpbmcBDAAAAAr_ggFUAQNmb28A"
+	assert.NilError(t, DecodePageTokenStruct(input, &actual))
+	expected := pageToken{
+		Int:    42,
+		String: "foo",
+	}
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Useful for page tokens that don't conform to the offset/checksum
standard.
