### PR TITLE
feat: support star in fieldmask.Validate

### DIFF
--- a/fieldmask/validate.go
+++ b/fieldmask/validate.go
@@ -12,6 +12,13 @@ import (
 // Validate validates that the paths in the provided field mask are syntactically valid and
 // refer to known fields in the specified message type.
 func Validate(fm *fieldmaskpb.FieldMask, m proto.Message) error {
+	// special case for '*'
+	if stringsContain("*", fm.GetPaths()) {
+		if len(fm.GetPaths()) != 1 {
+			return fmt.Errorf("invalid field path: '*' must not be used with other paths")
+		}
+		return nil
+	}
 	md0 := m.ProtoReflect().Descriptor()
 	for _, path := range fm.GetPaths() {
 		md := md0
@@ -44,6 +51,15 @@ func Validate(fm *fieldmaskpb.FieldMask, m proto.Message) error {
 		}
 	}
 	return nil
+}
+
+func stringsContain(str string, ss []string) bool {
+	for _, s := range ss {
+		if s == str {
+			return true
+		}
+	}
+	return false
 }
 
 func rangeFields(path string, f func(field string) bool) bool {

--- a/fieldmask/validate_test.go
+++ b/fieldmask/validate_test.go
@@ -18,6 +18,21 @@ func TestValidate(t *testing.T) {
 		errorContains string
 	}{
 		{
+			name:    "valid nil",
+			message: &library.Book{},
+		},
+		{
+			name:      "valid *",
+			fieldMask: &fieldmaskpb.FieldMask{Paths: []string{"*"}},
+			message:   &library.Book{},
+		},
+		{
+			name:          "invalid *",
+			fieldMask:     &fieldmaskpb.FieldMask{Paths: []string{"*", "author"}},
+			message:       &library.Book{},
+			errorContains: "invalid field path: '*' must not be used with other paths",
+		},
+		{
 			name:      "valid empty",
 			fieldMask: &fieldmaskpb.FieldMask{},
 			message:   &library.Book{},


### PR DESCRIPTION
Special '*' path is valid, even if message does not contain a field with
that path. It can not be combined with other paths.
