### PR TITLE
feat(filtering): initial support for macros

### DIFF
--- a/filtering/checker_test.go
+++ b/filtering/checker_test.go
@@ -393,7 +393,7 @@ func TestChecker(t *testing.T) {
 			}
 			assert.NilError(t, err)
 			var checker Checker
-			checker.Init(parsedExpr, declarations)
+			checker.Init(parsedExpr.Expr, parsedExpr.SourceInfo, declarations)
 			checkedExpr, err := checker.Check()
 			if tt.errorContains != "" {
 				assert.ErrorContains(t, err, tt.errorContains)

--- a/filtering/errors.go
+++ b/filtering/errors.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 type filterError interface {
@@ -90,10 +88,8 @@ func (p *parseError) Error() string {
 }
 
 type typeError struct {
-	expr       *expr.Expr
-	parsedExpr *expr.ParsedExpr
-	message    string
-	err        error
+	message string
+	err     error
 }
 
 func (t *typeError) Error() string {

--- a/filtering/filter.go
+++ b/filtering/filter.go
@@ -1,0 +1,10 @@
+package filtering
+
+import (
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+// Filter represents a parsed and type-checked filter.
+type Filter struct {
+	CheckedExpr *expr.CheckedExpr
+}

--- a/filtering/functions.go
+++ b/filtering/functions.go
@@ -66,9 +66,8 @@ func StandardFunctionDuration() *expr.Decl {
 // Has overloads.
 const (
 	FunctionOverloadHasString          = FunctionHas + "_string"
-	FunctionOverloadHasMap             = FunctionHas + "_map"
 	FunctionOverloadHasMapStringString = FunctionHas + "_map_string_string"
-	FunctionOverloadHasList            = FunctionHas + "_list"
+	FunctionOverloadHasListString      = FunctionHas + "_list_string"
 )
 
 // StandardFunctionHas returns a declaration for the standard `:` function and all its standard overloads.
@@ -78,6 +77,7 @@ func StandardFunctionHas() *expr.Decl {
 		NewFunctionOverload(FunctionOverloadHasString, TypeBool, TypeString, TypeString),
 		// TODO: Remove this after implementing support for type parameters.
 		NewFunctionOverload(FunctionOverloadHasMapStringString, TypeBool, TypeMap(TypeString, TypeString), TypeString),
+		NewFunctionOverload(FunctionOverloadHasListString, TypeBool, TypeList(TypeString), TypeString),
 	)
 }
 

--- a/filtering/macro.go
+++ b/filtering/macro.go
@@ -1,0 +1,88 @@
+package filtering
+
+import expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+
+// Macro represents a function that can perform macro replacements on a filter expression.
+type Macro func(*Cursor)
+
+// ApplyMacros applies the provided macros to the filter and type-checks the result against the provided declarations.
+func ApplyMacros(filter Filter, declarations *Declarations, macros ...Macro) (Filter, error) {
+	applyMacros(filter.CheckedExpr.Expr, filter.CheckedExpr.SourceInfo, macros...)
+	var checker Checker
+	checker.Init(filter.CheckedExpr.Expr, filter.CheckedExpr.SourceInfo, declarations)
+	checkedExpr, err := checker.Check()
+	if err != nil {
+		return Filter{}, err
+	}
+	filter.CheckedExpr = checkedExpr
+	return filter, nil
+}
+
+func applyMacros(exp *expr.Expr, sourceInfo *expr.SourceInfo, macros ...Macro) {
+	nextID := maxID(exp) + 1
+	Walk(func(currExpr, parentExpr *expr.Expr) bool {
+		cursor := &Cursor{
+			sourceInfo: sourceInfo,
+			currExpr:   currExpr,
+			parentExpr: parentExpr,
+			nextID:     nextID,
+		}
+		for _, macro := range macros {
+			macro(cursor)
+			if cursor.replaced {
+				// Don't traverse children of replaced expr.
+				return false
+			}
+		}
+		nextID = cursor.nextID
+		return true
+	}, exp)
+}
+
+// A Cursor describes an expression encountered while applying a Macro.
+//
+// The method Replace can be used to rewrite the filter.
+type Cursor struct {
+	parentExpr *expr.Expr
+	currExpr   *expr.Expr
+	sourceInfo *expr.SourceInfo
+	replaced   bool
+	nextID     int64
+}
+
+// Parent returns the parent of the current expression.
+func (c *Cursor) Parent() (*expr.Expr, bool) {
+	return c.parentExpr, c.parentExpr != nil
+}
+
+// Expr returns the current expression.
+func (c *Cursor) Expr() *expr.Expr {
+	return c.currExpr
+}
+
+// Replace the current expression with a new expression.
+func (c *Cursor) Replace(newExpr *expr.Expr) {
+	Walk(func(childExpr *expr.Expr, parentExpr *expr.Expr) bool {
+		childExpr.Id = c.nextID
+		c.nextID++
+		return true
+	}, newExpr)
+	if c.sourceInfo.MacroCalls == nil {
+		c.sourceInfo.MacroCalls = map[int64]*expr.Expr{}
+	}
+	c.sourceInfo.MacroCalls[newExpr.Id] = &expr.Expr{Id: c.currExpr.Id, ExprKind: c.currExpr.ExprKind}
+	c.currExpr.Id = newExpr.Id
+	c.currExpr.ExprKind = newExpr.ExprKind
+	c.replaced = true
+}
+
+func maxID(exp *expr.Expr) int64 {
+	var max int64
+	Walk(func(currExpr, parentExpr *expr.Expr) bool {
+		if exp.Id > max {
+			max = exp.Id
+		}
+		return true
+	}, exp)
+	return max
+}

--- a/filtering/macro_test.go
+++ b/filtering/macro_test.go
@@ -1,0 +1,94 @@
+package filtering
+
+import (
+	"testing"
+
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"google.golang.org/protobuf/testing/protocmp"
+	"gotest.tools/v3/assert"
+)
+
+func TestApplyMacros(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name              string
+		filter            string
+		declarations      []DeclarationOption
+		macros            []Macro
+		macroDeclarations []DeclarationOption
+		expected          *expr.Expr
+		errorContains     string
+	}{
+		{
+			filter: `annotations.schedule = "test"`,
+			declarations: []DeclarationOption{
+				DeclareStandardFunctions(),
+				DeclareIdent("annotations", TypeMap(TypeString, TypeString)),
+			},
+			macros: []Macro{
+				func(cursor *Cursor) {
+					callExpr := cursor.Expr().GetCallExpr()
+					if callExpr == nil {
+						return
+					}
+					if callExpr.Function != FunctionEquals {
+						return
+					}
+					if len(callExpr.Args) != 2 {
+						return
+					}
+					arg0Select := callExpr.Args[0].GetSelectExpr()
+					if arg0Select == nil || arg0Select.GetOperand().GetIdentExpr().GetName() != "annotations" {
+						return
+					}
+					arg1String := callExpr.Args[1].GetConstExpr().GetStringValue()
+					if arg1String == "" {
+						return
+					}
+					cursor.Replace(Has(arg0Select.Operand, String(arg0Select.Field+"="+arg1String)))
+				},
+			},
+			macroDeclarations: []DeclarationOption{
+				DeclareStandardFunctions(),
+				DeclareIdent("annotations", TypeList(TypeString)),
+			},
+			expected: Has(Text("annotations"), String("schedule=test")),
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			declarations, err := NewDeclarations(tt.declarations...)
+			assert.NilError(t, err)
+			filter, err := ParseFilter(&mockRequest{filter: tt.filter}, declarations)
+			if err != nil && tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+				return
+			}
+			assert.NilError(t, err)
+			macroDeclarations, err := NewDeclarations(tt.macroDeclarations...)
+			assert.NilError(t, err)
+			actual, err := ApplyMacros(filter, macroDeclarations, tt.macros...)
+			if err != nil && tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(
+				t,
+				tt.expected,
+				actual.CheckedExpr.Expr,
+				protocmp.Transform(),
+				protocmp.IgnoreFields(&expr.Expr{}, "id"),
+			)
+		})
+	}
+}
+
+type mockRequest struct {
+	filter string
+}
+
+func (m *mockRequest) GetFilter() string {
+	return m.filter
+}

--- a/filtering/request.go
+++ b/filtering/request.go
@@ -1,19 +1,8 @@
 package filtering
 
-import (
-	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
-	"google.golang.org/protobuf/reflect/protoreflect"
-)
-
 // Request is an interface for gRPC requests that contain a standard AIP filter.
 type Request interface {
 	GetFilter() string
-}
-
-// Filter represents a parsed and type-checked filter.
-type Filter struct {
-	CheckedExpr *expr.CheckedExpr
-	EnumMap     map[int64]protoreflect.EnumDescriptor
 }
 
 // ParseFilter parses and type-checks the filter in the provided Request.
@@ -28,7 +17,7 @@ func ParseFilter(request Request, declarations *Declarations) (Filter, error) {
 		return Filter{}, err
 	}
 	var checker Checker
-	checker.Init(parsedExpr, declarations)
+	checker.Init(parsedExpr.Expr, parsedExpr.SourceInfo, declarations)
 	checkedExpr, err := checker.Check()
 	if err != nil {
 		return Filter{}, err

--- a/filtering/walk.go
+++ b/filtering/walk.go
@@ -1,0 +1,46 @@
+package filtering
+
+import expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+
+// WalkFunc is called for every expression while calling Walk.
+// Return false to stop Walk.
+type WalkFunc func(currExpr, parentExpr *expr.Expr) bool
+
+// Walk an expression in depth-first order.
+func Walk(fn WalkFunc, currExpr *expr.Expr) {
+	walk(fn, currExpr, nil)
+}
+
+func walk(fn WalkFunc, currExpr, parentExpr *expr.Expr) {
+	if fn == nil || currExpr == nil {
+		return
+	}
+	if ok := fn(currExpr, parentExpr); !ok {
+		return
+	}
+	switch v := currExpr.ExprKind.(type) {
+	case *expr.Expr_ConstExpr, *expr.Expr_IdentExpr:
+		// Nothing to do here.
+	case *expr.Expr_SelectExpr:
+		walk(fn, v.SelectExpr.Operand, currExpr)
+	case *expr.Expr_CallExpr:
+		walk(fn, v.CallExpr.Target, currExpr)
+		for _, arg := range v.CallExpr.Args {
+			walk(fn, arg, currExpr)
+		}
+	case *expr.Expr_ListExpr:
+		for _, el := range v.ListExpr.Elements {
+			walk(fn, el, currExpr)
+		}
+	case *expr.Expr_StructExpr:
+		for _, entry := range v.StructExpr.Entries {
+			walk(fn, entry.Value, currExpr)
+		}
+	case *expr.Expr_ComprehensionExpr:
+		walk(fn, v.ComprehensionExpr.IterRange, currExpr)
+		walk(fn, v.ComprehensionExpr.AccuInit, currExpr)
+		walk(fn, v.ComprehensionExpr.LoopCondition, currExpr)
+		walk(fn, v.ComprehensionExpr.LoopStep, currExpr)
+		walk(fn, v.ComprehensionExpr.Result, currExpr)
+	}
+}


### PR DESCRIPTION
Enables rewriting of the filter expression, and re-checking types
against a separate set of declarations.

Useful when rewriting an expression for use in transpilation to a
database filter.
