### PR TITLE
feat: add resourcename.Scan

### DIFF
--- a/resourcename/sscan.go
+++ b/resourcename/sscan.go
@@ -1,0 +1,42 @@
+package resourcename
+
+import (
+	"fmt"
+	"io"
+)
+
+// Sscan scans a resource name, storing successive segments into successive variables
+// as determined by the provided pattern.
+func Sscan(name, pattern string, variables ...*string) error {
+	var nameScanner, patternScanner Scanner
+	nameScanner.Init(name)
+	patternScanner.Init(pattern)
+	var i int
+	for patternScanner.Scan() {
+		if patternScanner.Full() {
+			return fmt.Errorf("invalid pattern")
+		}
+		if !nameScanner.Scan() {
+			return fmt.Errorf("segment %s: %w", patternScanner.Segment(), io.ErrUnexpectedEOF)
+		}
+		nameSegment, patternSegment := nameScanner.Segment(), patternScanner.Segment()
+		if !patternSegment.IsVariable() {
+			if patternSegment.Literal() != nameSegment.Literal() {
+				return fmt.Errorf("segment %s: got %s", patternSegment, nameSegment)
+			}
+			continue
+		}
+		if i > len(variables)-1 {
+			return fmt.Errorf("segment %s: too few variables", patternSegment)
+		}
+		*variables[i] = string(nameSegment.Literal())
+		i++
+	}
+	if nameScanner.Scan() {
+		return fmt.Errorf("got trailing segments in name")
+	}
+	if i != len(variables) {
+		return fmt.Errorf("too many variables: got %d but expected %d", i, len(variables))
+	}
+	return nil
+}

--- a/resourcename/sscan_test.go
+++ b/resourcename/sscan_test.go
@@ -1,0 +1,146 @@
+package resourcename
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestScan(t *testing.T) {
+	t.Parallel()
+	t.Run("no variables", func(t *testing.T) {
+		t.Parallel()
+		assert.NilError(
+			t,
+			Sscan(
+				"publishers",
+				"publishers",
+			),
+		)
+	})
+
+	t.Run("single variable", func(t *testing.T) {
+		t.Parallel()
+		var publisher string
+		assert.NilError(
+			t,
+			Sscan(
+				"publishers/foo",
+				"publishers/{publisher}",
+				&publisher,
+			),
+		)
+		assert.Equal(t, "foo", publisher)
+	})
+
+	t.Run("two variables", func(t *testing.T) {
+		t.Parallel()
+		var publisher, book string
+		assert.NilError(
+			t,
+			Sscan(
+				"publishers/foo/books/bar",
+				"publishers/{publisher}/books/{book}",
+				&publisher,
+				&book,
+			),
+		)
+		assert.Equal(t, "foo", publisher)
+		assert.Equal(t, "bar", book)
+	})
+
+	t.Run("two variables singleton", func(t *testing.T) {
+		t.Parallel()
+		var publisher, book string
+		assert.NilError(
+			t,
+			Sscan(
+				"publishers/foo/books/bar/settings",
+				"publishers/{publisher}/books/{book}/settings",
+				&publisher,
+				&book,
+			),
+		)
+		assert.Equal(t, "foo", publisher)
+		assert.Equal(t, "bar", book)
+	})
+
+	t.Run("two variables singleton", func(t *testing.T) {
+		t.Parallel()
+		var publisher, book string
+		assert.NilError(
+			t,
+			Sscan(
+				"publishers/foo/books/bar/settings",
+				"publishers/{publisher}/books/{book}/settings",
+				&publisher,
+				&book,
+			),
+		)
+		assert.Equal(t, "foo", publisher)
+		assert.Equal(t, "bar", book)
+	})
+
+	t.Run("trailing segments", func(t *testing.T) {
+		t.Parallel()
+		var publisher, book string
+		assert.ErrorContains(
+			t,
+			Sscan(
+				"publishers/foo/books/bar/settings",
+				"publishers/{publisher}/books/{book}",
+				&publisher,
+				&book,
+			),
+			"trailing",
+		)
+	})
+
+	t.Run("too few variables", func(t *testing.T) {
+		t.Parallel()
+		var publisher string
+		assert.ErrorContains(
+			t,
+			Sscan(
+				"publishers/foo/books/bar/settings",
+				"publishers/{publisher}/books/{book}",
+				&publisher,
+			),
+			"too few variables",
+		)
+	})
+
+	t.Run("too many variables", func(t *testing.T) {
+		t.Parallel()
+		var publisher, book, extra string
+		assert.ErrorContains(
+			t,
+			Sscan(
+				"publishers/foo/books/bar",
+				"publishers/{publisher}/books/{book}",
+				&publisher,
+				&book,
+				&extra,
+			),
+			"too many variables",
+		)
+	})
+}
+
+// nolint: gochecknoglobals
+var benchmarkScanSink string
+
+func BenchmarkScan(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var publisher, book string
+		if err := Sscan(
+			"publishers/foo/books/bar",
+			"publishers/{publisher}/books/{book}",
+			&publisher,
+			&book,
+		); err != nil {
+			b.Fatal(err)
+		}
+		benchmarkScanSink = publisher
+	}
+}


### PR DESCRIPTION
Similar API to fmt.Sscanf but for resource names and patterns.

Scans a resource name and stores variable segments to string variables.

Useful for implementing resource name parsing.
