### PR TITLE
feat: add resourcename.Sprint

### DIFF
--- a/resourcename/sprint.go
+++ b/resourcename/sprint.go
@@ -1,0 +1,43 @@
+package resourcename
+
+import "strings"
+
+// Sprintf formats resource name variables according to a pattern and returns the resulting string.
+func Sprint(pattern string, variables ...string) string {
+	var length, segments int
+	var patternScanner Scanner
+	patternScanner.Init(pattern)
+	for patternScanner.Scan() {
+		segment := patternScanner.Segment()
+		if !segment.IsVariable() {
+			length += len(segment.Literal())
+		}
+		segments++
+	}
+	for _, variable := range variables {
+		length += len(variable)
+	}
+	if segments > 0 {
+		length += segments - 1
+	}
+	var result strings.Builder
+	result.Grow(length)
+	patternScanner.Init(pattern)
+	var i, variable int
+	for patternScanner.Scan() {
+		segment := patternScanner.Segment()
+		if segment.IsVariable() {
+			if variable < len(variables) {
+				_, _ = result.WriteString(variables[variable])
+				variable++
+			}
+		} else {
+			_, _ = result.WriteString(string(segment.Literal()))
+		}
+		if i < segments-1 {
+			_ = result.WriteByte('/')
+		}
+		i++
+	}
+	return result.String()
+}

--- a/resourcename/sprint_test.go
+++ b/resourcename/sprint_test.go
@@ -1,0 +1,80 @@
+package resourcename
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSprint(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name      string
+		pattern   string
+		variables []string
+		expected  string
+	}{
+		{
+			name:     "no variables",
+			pattern:  "singleton",
+			expected: "singleton",
+		},
+
+		{
+			name:      "too many variables",
+			pattern:   "singleton",
+			variables: []string{"foo"},
+			expected:  "singleton",
+		},
+
+		{
+			name:      "single variable",
+			pattern:   "publishers/{publisher}",
+			variables: []string{"foo"},
+			expected:  "publishers/foo",
+		},
+
+		{
+			name:      "two variables",
+			pattern:   "publishers/{publisher}/books/{book}",
+			variables: []string{"foo", "bar"},
+			expected:  "publishers/foo/books/bar",
+		},
+
+		{
+			name:      "singleton two variables",
+			pattern:   "publishers/{publisher}/books/{book}/settings",
+			variables: []string{"foo", "bar"},
+			expected:  "publishers/foo/books/bar/settings",
+		},
+
+		{
+			name:      "empty variable",
+			pattern:   "publishers/{publisher}/books/{book}",
+			variables: []string{"foo", ""},
+			expected:  "publishers/foo/books/",
+		},
+
+		{
+			name:      "too few variables",
+			pattern:   "publishers/{publisher}/books/{book}/settings",
+			variables: []string{"foo"},
+			expected:  "publishers/foo/books//settings",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, Sprint(tt.pattern, tt.variables...))
+		})
+	}
+}
+
+// nolint: gochecknoglobals
+var benchmarkSprintSink string
+
+func BenchmarkSprint(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmarkSprintSink = Sprint("publishers/{publisher}/books/{book}", "foo", "bar")
+	}
+}


### PR DESCRIPTION
Formats a resource name string from a pattern and variables, with
similar API as fmt.Sprintf.
