### PR TITLE
feat: rename resourcename.Matches to resourcename.Match

### DIFF
--- a/resourcename/matches.go
+++ b/resourcename/matches.go
@@ -1,7 +1,7 @@
 package resourcename
 
-// Matches reports whether the specified resource name matches the specified resource name pattern.
-func Matches(name, pattern string) bool {
+// Match reports whether the specified resource name matches the specified resource name pattern.
+func Match(pattern, name string) bool {
 	var nameScanner, patternScanner Scanner
 	nameScanner.Init(name)
 	patternScanner.Init(pattern)

--- a/resourcename/matches_test.go
+++ b/resourcename/matches_test.go
@@ -73,7 +73,7 @@ func TestMatches(t *testing.T) {
 		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			t.Parallel()
-			assert.Assert(t, Matches(tt.name, tt.pattern) == tt.expected)
+			assert.Assert(t, Match(tt.pattern, tt.name) == tt.expected)
 		})
 	}
 }


### PR DESCRIPTION
For parity with regexp.Match, also reorderes the arguments to put the
pattern first.
