### PR TITLE
fix(filtering): set expr.ID on nested AND expressions

### DIFF
--- a/filtering/parser.go
+++ b/filtering/parser.go
@@ -86,10 +86,11 @@ func (p *Parser) ParseExpression() (_ *expr.Expr, err error) {
 			break
 		}
 	}
-	if len(sequences) == 1 {
-		return sequences[0], nil
+	exp := sequences[0]
+	for _, seq := range sequences[1:] {
+		exp = parsedExpression(p.nextID(start), exp, seq)
 	}
-	return parsedExpression(p.nextID(start), sequences...), nil
+	return exp, nil
 }
 
 // ParseSequence parses a Sequence.

--- a/filtering/parser_test.go
+++ b/filtering/parser_test.go
@@ -56,6 +56,14 @@ func TestParser(t *testing.T) {
 				GreaterEquals(Text("a"), Int(100)),
 			),
 		},
+		{
+			filter: "a OR b OR c",
+			expected: Or(
+				Text("a"),
+				Text("b"),
+				Text("c"),
+			),
+		},
 
 		{
 			filter:   "NOT (a OR b)",
@@ -251,7 +259,20 @@ func TestParser(t *testing.T) {
 					protocmp.Transform(),
 					protocmp.IgnoreFields(&expr.Expr{}, "id"),
 				)
+				assertUniqueExprIDs(t, actual.Expr)
 			}
 		})
 	}
+}
+
+func assertUniqueExprIDs(t *testing.T, exp *expr.Expr) {
+	t.Helper()
+	seenIDs := make(map[int64]struct{})
+	Walk(func(currExpr, parentExpr *expr.Expr) bool {
+		if _, ok := seenIDs[currExpr.Id]; ok {
+			t.Fatalf("duplicate expression ID '%d' for expr %v", currExpr.Id, currExpr)
+		}
+		seenIDs[currExpr.Id] = struct{}{}
+		return true
+	}, exp)
 }


### PR DESCRIPTION
Previously nested AND expressions (ex: "a AND b AND c") would not set an
ID on the innermost AND expression. This commit changes the "folding" of
a sequence of AND expressions to be similar to OR expressions.

Also adds a test to ensure that all tested expressions produce
subexpressions with unique IDs.

This fixes an issue where type checking fails because of duplicate IDs.
