### PR TITLE
fix(filtering): always increment next id when applying macros

### DIFF
--- a/filtering/macro.go
+++ b/filtering/macro.go
@@ -29,12 +29,12 @@ func applyMacros(exp *expr.Expr, sourceInfo *expr.SourceInfo, macros ...Macro) {
 		}
 		for _, macro := range macros {
 			macro(cursor)
+			nextID = cursor.nextID
 			if cursor.replaced {
 				// Don't traverse children of replaced expr.
 				return false
 			}
 		}
-		nextID = cursor.nextID
 		return true
 	}, exp)
 }


### PR DESCRIPTION
Next ID was never updated when a macro replaced a subexpression, leading
to duplicate IDs down the line.
