### PR TITLE
fix(fieldmask): dont populate message type when updating from nil

### DIFF
--- a/fieldmask/update.go
+++ b/fieldmask/update.go
@@ -77,7 +77,7 @@ func updateNamedField(dst, src protoreflect.Message, segments []string) {
 	// a named field in this message
 	if len(segments) == 1 {
 		if !src.Has(field) {
-			dst.Set(field, src.NewField(field))
+			dst.Clear(field)
 		} else {
 			dst.Set(field, src.Get(field))
 		}

--- a/fieldmask/update_test.go
+++ b/fieldmask/update_test.go
@@ -713,7 +713,7 @@ func TestUpdate(t *testing.T) {
 					},
 				},
 				expected: &syntaxv1.Message{
-					Oneof: &syntaxv1.Message_OneofMessage2{},
+					Oneof: nil,
 				},
 			},
 			{
@@ -766,6 +766,23 @@ func TestUpdate(t *testing.T) {
 					Oneof: &syntaxv1.Message_OneofMessage2{
 						OneofMessage2: &syntaxv1.Message{},
 					},
+				},
+			},
+			{
+				name: "message: src nil",
+				paths: []string{
+					"message",
+				},
+				src: &syntaxv1.Message{
+					Message: nil,
+				},
+				dst: &syntaxv1.Message{
+					Message: &syntaxv1.Message{
+						Int32: 23,
+					},
+				},
+				expected: &syntaxv1.Message{
+					Message: nil,
 				},
 			},
 		} {


### PR DESCRIPTION
Previously when calling `Update` with paths in the fieldmask which
covered message fields, this method would allocate a new empty message
instead of nil.

Concretely this meant that timestamps could not be properly unset with a
fieldmask, as they would not become nil but rather `{ Seconds: 0, Nanos:
0}` which is a valid timestamp.

This also changes how oneofs are Updated when the source does not
specify a kind. This is the correct behavior.
