### PR TITLE
feat(validation): improve error presentation

### DIFF
--- a/validation/error.go
+++ b/validation/error.go
@@ -61,7 +61,7 @@ func (e *Error) Error() string {
 			var result strings.Builder
 			_, _ = result.WriteString("field violation on multiple fields:\n")
 			for i, fieldViolation := range e.fieldViolations {
-				_, _ = result.WriteString(fmt.Sprintf("\t%s: %s", fieldViolation.Field, fieldViolation.Description))
+				_, _ = result.WriteString(fmt.Sprintf(" | %s: %s", fieldViolation.Field, fieldViolation.Description))
 				if i < len(e.fieldViolations)-1 {
 					_ = result.WriteByte('\n')
 				}

--- a/validation/error_test.go
+++ b/validation/error_test.go
@@ -28,8 +28,8 @@ func TestError_Error(t *testing.T) {
 		{Field: "baz", Description: "test2"},
 	})
 	assert.Error(t, err, `field violation on multiple fields:
-	foo.bar: test
-	baz: test2`)
+ | foo.bar: test
+ | baz: test2`)
 }
 
 func TestError_GRPCStatus(t *testing.T) {


### PR DESCRIPTION
Start lines related to the same error with `|` to increase readability.
