### PR TITLE
feat(filtering/exprs): package for working with exprs

### DIFF
--- a/filtering/exprs/doc.go
+++ b/filtering/exprs/doc.go
@@ -1,0 +1,2 @@
+// Package exprs provides primitives for working with v1alpha1/expr values.
+package exprs

--- a/filtering/exprs/match.go
+++ b/filtering/exprs/match.go
@@ -1,0 +1,174 @@
+package exprs
+
+import (
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+// Matcher returns true if the expr matches the predicate.
+type Matcher func(exp *expr.Expr) bool
+
+// MatchString matches an expr.Constant_StringValue with an
+// exact value.
+func MatchString(s string) Matcher {
+	var s2 string
+	m := MatchAnyString(&s2)
+	return func(exp *expr.Expr) bool {
+		return m(exp) && s == s2
+	}
+}
+
+// MatchAnyString matches an expr.Constant_StringValue with any
+// value. The value of the expr is populated in argument value.
+func MatchAnyString(value *string) Matcher {
+	return func(exp *expr.Expr) bool {
+		cons := exp.GetConstExpr()
+		if cons == nil {
+			return false
+		}
+		if _, ok := cons.ConstantKind.(*expr.Constant_StringValue); !ok {
+			return false
+		}
+		*value = cons.GetStringValue()
+		return true
+	}
+}
+
+// MatchFloat matches an expr.Constant_DoubleValue with an exact value.
+func MatchFloat(value float64) Matcher {
+	var f2 float64
+	m := MatchAnyFloat(&f2)
+	return func(exp *expr.Expr) bool {
+		return m(exp) && value == f2
+	}
+}
+
+// MatchAnyFloat matches an expr.Constant_DoubleValue with any value.
+// The value of the expr is populated in argument value.
+func MatchAnyFloat(value *float64) Matcher {
+	return func(exp *expr.Expr) bool {
+		cons := exp.GetConstExpr()
+		if cons == nil {
+			return false
+		}
+		if _, ok := cons.ConstantKind.(*expr.Constant_DoubleValue); !ok {
+			return false
+		}
+		*value = cons.GetDoubleValue()
+		return true
+	}
+}
+
+// MatchInt matches an expr.Constant_Int64Value with an exact value.
+func MatchInt(value int64) Matcher {
+	var i2 int64
+	m := MatchAnyInt(&i2)
+	return func(exp *expr.Expr) bool {
+		return m(exp) && value == i2
+	}
+}
+
+// MatchAnyInt matches an expr.Constant_Int64Value with any value.
+// The value of the expr is populated in argument value.
+func MatchAnyInt(value *int64) Matcher {
+	return func(exp *expr.Expr) bool {
+		cons := exp.GetConstExpr()
+		if cons == nil {
+			return false
+		}
+		if _, ok := cons.ConstantKind.(*expr.Constant_Int64Value); !ok {
+			return false
+		}
+		*value = cons.GetInt64Value()
+		return true
+	}
+}
+
+// MatchText matches an expr.Expr_Ident where the name
+// of the ident matches an exact value.
+func MatchText(text string) Matcher {
+	var t2 string
+	m := MatchAnyText(&t2)
+	return func(exp *expr.Expr) bool {
+		return m(exp) && text == t2
+	}
+}
+
+// MatchAnyText matches an expr.Expr_Ident with any name.
+// The name of the expr is populated in argument text.
+func MatchAnyText(text *string) Matcher {
+	return func(exp *expr.Expr) bool {
+		ident := exp.GetIdentExpr()
+		if ident == nil {
+			return false
+		}
+		*text = ident.GetName()
+		return true
+	}
+}
+
+// MatchMember matches an expr.Expr_Select where the operand matches
+// the argument operand, and the field matches argument field.
+func MatchMember(operand Matcher, field string) Matcher {
+	var f2 string
+	m := MatchAnyMember(operand, &f2)
+	return func(exp *expr.Expr) bool {
+		return m(exp) && field == f2
+	}
+}
+
+// MatchAnyMember matches an expr.Expr_Select where the operand matches
+// the argument operand. The field of the expr is populated in argument field.
+func MatchAnyMember(operand Matcher, field *string) Matcher {
+	return func(exp *expr.Expr) bool {
+		sel := exp.GetSelectExpr()
+		if sel == nil {
+			return false
+		}
+		if !operand(sel.GetOperand()) {
+			return false
+		}
+		*field = sel.GetField()
+		return true
+	}
+}
+
+// MatchFunction matches an expr.Expr_Call where the name of the
+// expr matches argument name, and arguments of the function matches
+// the provided args (length must match).
+func MatchFunction(name string, args ...Matcher) Matcher {
+	var n2 string
+	m := MatchAnyFunction(&n2, args...)
+	return func(exp *expr.Expr) bool {
+		return m(exp) && name == n2
+	}
+}
+
+// MatchAnyFunction matches an expr.Expr_Call where the provided args
+// matches the function arguments. The name of the function is populated
+// in argument name.
+func MatchAnyFunction(name *string, args ...Matcher) Matcher {
+	return func(exp *expr.Expr) bool {
+		call := exp.GetCallExpr()
+		if call == nil {
+			return false
+		}
+		if len(call.GetArgs()) != len(args) {
+			return false
+		}
+		for i, a := range call.GetArgs() {
+			if !args[i](a) {
+				return false
+			}
+		}
+		*name = call.GetFunction()
+		return true
+	}
+}
+
+// MatchAny matches any expr.Expr. The expr is populated in argument e.
+func MatchAny(e **expr.Expr) Matcher {
+	return func(exp *expr.Expr) bool {
+		*e = exp
+		return true
+	}
+}

--- a/filtering/exprs/match_example_test.go
+++ b/filtering/exprs/match_example_test.go
@@ -1,0 +1,48 @@
+package exprs
+
+import (
+	"fmt"
+
+	"go.einride.tech/aip/filtering"
+	"go.einride.tech/aip/resourcename"
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+func ExampleMatchFunction_validateResourceNames() {
+	const pattern = "books/{book}"
+
+	var walkErr error
+	walkFn := func(currExpr, _ *expr.Expr) bool {
+		var name string
+		// match any function expression with name '=' and LHS 'name'
+		matcher := MatchFunction(filtering.FunctionEquals, MatchText("name"), MatchAnyString(&name))
+		if matcher(currExpr) && !resourcename.Match(pattern, name) {
+			walkErr = fmt.Errorf("expected resource name matching '%s' but got '%s'", pattern, name)
+			return false
+		}
+		return true
+	}
+
+	// name = "not a resource name" or name = "books/2"
+	invalidExpr := filtering.Or(
+		filtering.Equals(filtering.Text("name"), filtering.String("not a resource name")),
+		filtering.Equals(filtering.Text("name"), filtering.String("books/2")),
+	)
+	filtering.Walk(walkFn, invalidExpr)
+	fmt.Println(walkErr)
+
+	// reset
+	walkErr = nil
+
+	// name = "books/1" or name = "books/2"
+	validExpr := filtering.Or(
+		filtering.Equals(filtering.Text("name"), filtering.String("books/1")),
+		filtering.Equals(filtering.Text("name"), filtering.String("books/2")),
+	)
+	filtering.Walk(walkFn, validExpr)
+	fmt.Println(walkErr)
+
+	// Output:
+	// expected resource name matching 'books/{book}' but got 'not a resource name'
+	// <nil>
+}

--- a/filtering/exprs/match_test.go
+++ b/filtering/exprs/match_test.go
@@ -1,0 +1,238 @@
+package exprs
+
+import (
+	"testing"
+
+	"go.einride.tech/aip/filtering"
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"google.golang.org/protobuf/testing/protocmp"
+	"gotest.tools/v3/assert"
+)
+
+func TestMatch(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		expr     *expr.Expr
+		matcher  Matcher
+		expected bool
+	}{
+		{
+			name:     "string: match",
+			matcher:  MatchString("string"),
+			expr:     filtering.String("string"),
+			expected: true,
+		},
+		{
+			name:    "string: another expr",
+			matcher: MatchString("string"),
+			expr:    filtering.Text("state"),
+		},
+		{
+			name:    "string: wrong string",
+			matcher: MatchString("string"),
+			expr:    filtering.String("another string"),
+		},
+		{
+			name:     "float: match",
+			matcher:  MatchFloat(3.14),
+			expr:     filtering.Float(3.14),
+			expected: true,
+		},
+		{
+			name:    "float: another expr",
+			matcher: MatchFloat(3.14),
+			expr:    filtering.Text("state"),
+		},
+		{
+			name:    "float: wrong float",
+			matcher: MatchFloat(3.14),
+			expr:    filtering.Float(1.23),
+		},
+		{
+			name:     "int: match",
+			matcher:  MatchInt(3),
+			expr:     filtering.Int(3),
+			expected: true,
+		},
+		{
+			name:    "int: another expr",
+			matcher: MatchInt(3),
+			expr:    filtering.Text("state"),
+		},
+		{
+			name:    "int: wrong int",
+			matcher: MatchInt(3),
+			expr:    filtering.Int(1),
+		},
+		{
+			name:     "text: match",
+			matcher:  MatchText("text"),
+			expr:     filtering.Text("text"),
+			expected: true,
+		},
+		{
+			name:    "text: another expr",
+			matcher: MatchText("text"),
+			expr:    filtering.Text("state"),
+		},
+		{
+			name:    "text: wrong text",
+			matcher: MatchText("text"),
+			expr:    filtering.Text("another_text"),
+		},
+		{
+			name:     "member: match",
+			matcher:  MatchMember(MatchText("operand"), "field"),
+			expr:     filtering.Member(filtering.Text("operand"), "field"),
+			expected: true,
+		},
+		{
+			name:    "member: another expr",
+			matcher: MatchMember(MatchText("operand"), "field"),
+			expr:    filtering.Text("state"),
+		},
+		{
+			name:    "member: wrong field",
+			matcher: MatchMember(MatchText("operand"), "field"),
+			expr:    filtering.Member(filtering.Text("operand"), "another_field"),
+		},
+		{
+			name: "function: match",
+			matcher: MatchFunction(
+				"=",
+				MatchString("lhs"),
+				MatchString("rhs"),
+			),
+			expr: filtering.Function(
+				"=",
+				filtering.String("lhs"),
+				filtering.String("rhs"),
+			),
+			expected: true,
+		},
+		{
+			name: "function: another expr",
+			matcher: MatchFunction(
+				"=",
+				MatchString("lhs"),
+				MatchString("rhs"),
+			),
+			expr: filtering.Text("state"),
+		},
+		{
+			name: "function: wrong number of args",
+			matcher: MatchFunction(
+				"=",
+				MatchString("lhs"),
+				MatchString("rhs"),
+			),
+			expr: filtering.Function(
+				"=",
+				filtering.String("lhs"),
+			),
+		},
+		{
+			name: "function: wrong name",
+			matcher: MatchFunction(
+				"=",
+				MatchString("lhs"),
+				MatchString("rhs"),
+			),
+			expr: filtering.Function(
+				"*",
+				filtering.String("lhs"),
+				filtering.String("rhs"),
+			),
+		},
+		{
+			name: "function: wrong number of args",
+			matcher: MatchFunction(
+				"=",
+				MatchString("lhs"),
+				MatchString("rhs"),
+			),
+			expr: filtering.Function(
+				"=",
+				filtering.String("lhs"),
+			),
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.matcher(tt.expr)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestMatchAny(t *testing.T) {
+	t.Parallel()
+	t.Run("String", func(t *testing.T) {
+		t.Parallel()
+		var val string
+		matcher := MatchAnyString(&val)
+		exp := filtering.String("x")
+
+		assert.Check(t, matcher(exp))
+		assert.Equal(t, "x", val)
+	})
+	t.Run("Float", func(t *testing.T) {
+		t.Parallel()
+		var val float64
+		matcher := MatchAnyFloat(&val)
+		exp := filtering.Float(3.14)
+
+		assert.Check(t, matcher(exp))
+		assert.Equal(t, 3.14, val)
+	})
+	t.Run("Int", func(t *testing.T) {
+		t.Parallel()
+		var val int64
+		matcher := MatchAnyInt(&val)
+		exp := filtering.Int(3)
+
+		assert.Check(t, matcher(exp))
+		assert.Equal(t, int64(3), val)
+	})
+	t.Run("Text", func(t *testing.T) {
+		t.Parallel()
+		var val string
+		matcher := MatchAnyText(&val)
+		exp := filtering.Text("x")
+
+		assert.Check(t, matcher(exp))
+		assert.Equal(t, "x", val)
+	})
+	t.Run("Member", func(t *testing.T) {
+		t.Parallel()
+		var operand, field string
+		matcher := MatchAnyMember(MatchAnyText(&operand), &field)
+		exp := filtering.Member(filtering.Text("operand"), "field")
+
+		assert.Check(t, matcher(exp))
+		assert.Equal(t, "operand", operand)
+		assert.Equal(t, "field", field)
+	})
+	t.Run("Function", func(t *testing.T) {
+		t.Parallel()
+		var fn, lhs, rhs string
+		matcher := MatchAnyFunction(&fn, MatchAnyString(&lhs), MatchAnyString(&rhs))
+		exp := filtering.Function("=", filtering.String("lhs"), filtering.String("rhs"))
+
+		assert.Check(t, matcher(exp))
+		assert.Equal(t, "=", fn)
+		assert.Equal(t, "lhs", lhs)
+		assert.Equal(t, "rhs", rhs)
+	})
+	t.Run("Any", func(t *testing.T) {
+		t.Parallel()
+		ex := &expr.Expr{}
+		matcher := MatchAny(&ex)
+		exp := filtering.Function("=", filtering.String("lhs"), filtering.String("rhs"))
+
+		assert.Check(t, matcher(exp))
+		assert.DeepEqual(t, exp, ex, protocmp.Transform())
+	})
+}


### PR DESCRIPTION
When using filters in APIs it is typical to validate the filter (for
example resource names) and transform it to a database schema.

The `filtering` package already exposes functionality for walking
(`filtering.Walk`) and transforming (`filtering.ApplyMacros`) exprs.
When using either of those methods some functions should be applied to
only parts of the expression tree, which typically results multiple if
statements parsing the expression.

The `exprs` package exposes several `Matcher` functions which can be
used to match parts of the expression tree. See the Go example for an
example use case.
