### PR TITLE
fix(resourceid): update ValidateUserSettable

### DIFF
--- a/resourceid/usersettable.go
+++ b/resourceid/usersettable.go
@@ -2,6 +2,7 @@ package resourceid
 
 import (
 	"fmt"
+	"unicode"
 
 	"github.com/google/uuid"
 )
@@ -10,8 +11,9 @@ import (
 //
 // From https://google.aip.dev/122#resource-id-segments:
 //
-// User-settable resource IDs should conform to RFC-1034,which restricts to letters, numbers, and hyphen, with a 63
-// character maximum. Additionally, user-settable resource IDs should restrict letters to lower-case.
+// User-settable resource IDs should conform to RFC-1034; which restricts to letters, numbers, and hyphen,
+// with the first character a letter, the last a letter or a number, and a 63 character maximum.
+// Additionally, user-settable resource IDs should restrict letters to lower-case.
 //
 // User-settable IDs should not be permitted to be a UUID (or any value that syntactically appears to be a UUID).
 //
@@ -20,8 +22,11 @@ func ValidateUserSettable(id string) error {
 	if len(id) < 4 || 63 < len(id) {
 		return fmt.Errorf("user-settable ID must be between 4 and 63 characters")
 	}
-	if id[0] == '-' {
-		return fmt.Errorf("user-settable ID must not start with a hyphen")
+	if !unicode.IsLetter(rune(id[0])) {
+		return fmt.Errorf("user-settable ID must begin with a letter")
+	}
+	if id[len(id)-1] == '-' {
+		return fmt.Errorf("user-settable ID must end with a letter or number")
 	}
 	if _, err := uuid.Parse(id); err == nil {
 		return fmt.Errorf("user-settable ID must not be a valid UUIDv4")

--- a/resourceid/usersettable_test.go
+++ b/resourceid/usersettable_test.go
@@ -15,7 +15,9 @@ func TestValidateUserSettable(t *testing.T) {
 		{id: "abcd"},
 		{id: "abcd-efgh-1234"},
 		{id: "abc", errorContains: "must be between 4 and 63 characters"},
-		{id: "-abc", errorContains: "must not start with a hyphen"},
+		{id: "-abc", errorContains: "must begin with a letter"},
+		{id: "abc-", errorContains: "must end with a letter or number"},
+		{id: "123-abc", errorContains: "must begin with a letter"},
 		{id: "daf1cb3e-f33b-43f1-81cc-e65fda51efa5", errorContains: "must not be a valid UUIDv4"},
 		{id: "abcd/efgh", errorContains: "must only contain lowercase, numbers and hyphens"},
 	} {


### PR DESCRIPTION
Add additional checks to conform to RFC-1034, i.e.,
user-settable resource ID must begin with a letter and
end with a letter or number.

See aip-dev/google.aip.dev#724 for the clarification.
