### PR TITLE
feat(enums): add support for not equals functions on enums

### DIFF
--- a/filtering/declarations.go
+++ b/filtering/declarations.go
@@ -164,11 +164,16 @@ func (d *Declarations) declareEnumIdent(name string, enumType protoreflect.EnumT
 	if err := d.declareIdent(name, enumIdentType); err != nil {
 		return err
 	}
-	if err := d.declareFunction(
+	for _, fn := range []string{
 		FunctionEquals,
-		NewFunctionOverload(FunctionEquals+"_"+enumIdentType.GetMessageType(), TypeBool, enumIdentType, enumIdentType),
-	); err != nil {
-		return err
+		FunctionNotEquals,
+	} {
+		if err := d.declareFunction(
+			fn,
+			NewFunctionOverload(fn+"_"+enumIdentType.GetMessageType(), TypeBool, enumIdentType, enumIdentType),
+		); err != nil {
+			return err
+		}
 	}
 	values := enumType.Descriptor().Values()
 	for i := 0; i < values.Len(); i++ {


### PR DESCRIPTION
Previously we only supported equals operation on enums. This PR adds support for not equals as well.﻿
