### PR TITLE
fix(ci): allow users without write permissions to make releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.15
 
       - name: Setup Node
         uses: actions/setup-node@v2-beta
@@ -31,6 +31,8 @@ jobs:
   release:
     needs: [make]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
@@ -39,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.15
 
       - name: Setup Node
         uses: actions/setup-node@v2-beta

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,3 +26,6 @@ linters:
     - thelper # false positives
     - tagliatelle # false positives
     - forcetypeassert # not useful for proto.GetExtension
+    - maligned # deprecated upstream, replaced by govet 'fieldalignment'
+    - golint # deprecated upstream, replaced by revive
+    - scopelint # deprecated upstream, replaced by exportloopref


### PR DESCRIPTION
this is needed when for example dependabot merges a PR.

Also downgraded Go to 1.15 to match the minimum required version in the go.mod file.
Maybe we should add a matrix step to test 15, 16, and 17 perhaps?

_Also disabled replaced/deprecated linters_