### PR TITLE
fix(resourcename): inifinite loop on certain pattern

### DIFF
--- a/resourcename/matches_test.go
+++ b/resourcename/matches_test.go
@@ -1,6 +1,7 @@
 package resourcename
 
 import (
+	"fmt"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -69,11 +70,29 @@ func TestMatches(t *testing.T) {
 			pattern:  "//freight-example.einride.tech/shippers/{shipper}",
 			expected: false,
 		},
+
+		{
+			test:     "slash prefix in the name",
+			name:     "/shippers/1",
+			pattern:  "shippers/{shipper}",
+			expected: true,
+		},
+
+		{
+			test:     "slash prefix in the pattern",
+			name:     "shippers/1",
+			pattern:  "/shippers/{shipper}",
+			expected: true,
+		},
 	} {
 		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			t.Parallel()
-			assert.Assert(t, Match(tt.pattern, tt.name) == tt.expected)
+			assert.Check(
+				t,
+				Match(tt.pattern, tt.name) == tt.expected,
+				fmt.Sprintf("expected Match(%q, %q)=%t", tt.pattern, tt.name, tt.expected),
+			)
 		})
 	}
 }

--- a/resourcename/scanner.go
+++ b/resourcename/scanner.go
@@ -37,6 +37,8 @@ func (s *Scanner) Scan() bool {
 			}
 			s.serviceStart, s.serviceEnd = s.start, s.start+nextSlash
 			s.start, s.end = s.start+nextSlash+1, s.start+nextSlash+1
+		} else if strings.HasPrefix(s.name, "/") {
+			s.start = s.end + 1 // start past beginning slash
 		}
 	default:
 		s.start = s.end + 1 // start past latest slash


### PR DESCRIPTION
when the resourcename pattern starts with a single slash we got into a corner case where the matcher would loop infinitely.