### PR TITLE
fieldmask: consider field behavior for applying updates

### DIFF
--- a/fieldmask/update.go
+++ b/fieldmask/update.go
@@ -1,8 +1,8 @@
 package fieldmask
 
 import (
-	"bytes"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"go.einride.tech/aip/fieldbehavior"
@@ -10,6 +10,12 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+const (
+	updateModeWire int = 0
+	updateModeFull int = 1
+	updateModePath int = 2
 )
 
 // Update updates fields in dst with values from src according to the provided field mask.
@@ -22,7 +28,7 @@ import (
 // If the special value "*" is provided as the field mask, a full replacement of all fields in dst is done.
 //
 // See: https://google.aip.dev/134 (Standard methods: Update).
-func Update(mask *fieldmaskpb.FieldMask, dst, src proto.Message) {
+func Update(mask *fieldmaskpb.FieldMask, dst, src proto.Message) error {
 	dstReflect := dst.ProtoReflect()
 	srcReflect := src.ProtoReflect()
 	if dstReflect.Descriptor() != srcReflect.Descriptor() {
@@ -32,112 +38,81 @@ func Update(mask *fieldmaskpb.FieldMask, dst, src proto.Message) {
 			srcReflect.Descriptor().FullName(),
 		))
 	}
+	var err error
 	switch {
-	// Special-case: No update mask.
-	// Update all fields of src that are set on the wire.
 	case len(mask.GetPaths()) == 0:
-		updateWireSetFields(dstReflect, srcReflect)
-	// Special-case: Update mask is [*].
-	// Do a full replacement of all fields.
+		err = applyUpdate(dstReflect, srcReflect, updateModeWire)
 	case IsFullReplacement(mask):
-		proto.Reset(dst)
-		proto.Merge(dst, src)
+		err = applyUpdate(dstReflect, srcReflect, updateModeFull)
 	default:
 		for _, path := range mask.GetPaths() {
 			segments := strings.Split(path, ".")
-			updateNamedField(dstReflect, srcReflect, segments)
-		}
-	}
-}
-
-func updateWireSetFields(dst, src protoreflect.Message) {
-	src.Range(func(field protoreflect.FieldDescriptor, value protoreflect.Value) bool {
-		switch {
-		case field.IsList():
-			dst.Set(field, value)
-		case field.IsMap():
-			dst.Set(field, value)
-		case field.Message() != nil && !dst.Has(field):
-			dst.Set(field, value)
-		case field.Message() != nil:
-			updateWireSetFields(dst.Get(field).Message(), value.Message())
-		default:
-			dst.Set(field, value)
-		}
-		return true
-	})
-}
-
-func updateNamedField(dst, src protoreflect.Message, segments []string) {
-	if len(segments) == 0 {
-		return
-	}
-	field := src.Descriptor().Fields().ByName(protoreflect.Name(segments[0]))
-	if field == nil {
-		// no known field by that name
-		return
-	}
-	if fieldbehavior.Has(field, annotations.FieldBehavior_OUTPUT_ONLY) {
-		return
-	}
-	// a named field in this message
-	if len(segments) == 1 {
-		if fieldbehavior.Has(field, annotations.FieldBehavior_IMMUTABLE) {
-			srcFld := src.Get(field)
-			dstFld := dst.Get(field)
-			cmp := true
-			switch field.Kind() {
-			case protoreflect.EnumKind:
-				cmp = srcFld.Enum() != dstFld.Enum()
-			case protoreflect.BoolKind:
-				cmp = srcFld.Bool() != dstFld.Bool()
-			case protoreflect.Int32Kind,
-				protoreflect.Sint32Kind,
-				protoreflect.Int64Kind,
-				protoreflect.Sint64Kind,
-				protoreflect.Sfixed32Kind,
-				protoreflect.Sfixed64Kind:
-				cmp = srcFld.Int() == dstFld.Int()
-			case protoreflect.Uint32Kind,
-				protoreflect.Uint64Kind,
-				protoreflect.Fixed32Kind,
-				protoreflect.Fixed64Kind:
-				cmp = srcFld.Uint() == dstFld.Uint()
-			case protoreflect.FloatKind,
-				protoreflect.DoubleKind:
-				cmp = srcFld.Float() == dstFld.Float()
-			case protoreflect.StringKind:
-				cmp = srcFld.String() == dstFld.String()
-			case protoreflect.BytesKind:
-				cmp = bytes.Equal(srcFld.Bytes(), dstFld.Bytes())
-			}
-			if !cmp {
-				return
+			err = applyUpdate(dstReflect, srcReflect, updateModePath, segments...)
+			if err != nil {
+				return err
 			}
 		}
-		if !src.Has(field) {
-			dst.Clear(field)
-		} else {
-			dst.Set(field, src.Get(field))
-		}
-		return
 	}
+	return err
+}
 
-	// a named field in a nested message
-	switch {
-	case field.IsList(), field.IsMap():
-		// nested fields in repeated or map not supported
-		return
-	case field.Message() != nil:
-		// if message field is not set, allocate an empty value
-		if !dst.Has(field) {
-			dst.Set(field, dst.NewField(field))
+func applyUpdate(dst, src protoreflect.Message, mode int, segments ...string) error {
+	var err error
+	if mode == updateModePath && len(segments) > 0 {
+		field := src.Descriptor().Fields().ByName(protoreflect.Name(segments[0]))
+		if field != nil && !fieldbehavior.Has(field, annotations.FieldBehavior_OUTPUT_ONLY) {
+			if len(segments) == 1 {
+				err = updateField(field, dst, src)
+			} else {
+				switch {
+				case field.IsList(), field.IsMap():
+					// nested fields in repeated or map not supported
+				case field.Message() != nil:
+					// if message field is not set, allocate an empty value
+					if !dst.Has(field) {
+						dst.Set(field, dst.NewField(field))
+					}
+					if !src.Has(field) {
+						src.Set(field, src.NewField(field))
+					}
+					applyUpdate(dst.Get(field).Message(), src.Get(field).Message(), mode, segments[1:]...)
+				}
+			}
 		}
-		if !src.Has(field) {
-			src.Set(field, src.NewField(field))
-		}
-		updateNamedField(dst.Get(field).Message(), src.Get(field).Message(), segments[1:])
-	default:
-		return
+	} else {
+		src.Range(func(field protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+			if fieldbehavior.Has(field, annotations.FieldBehavior_OUTPUT_ONLY) {
+				return true
+			}
+			if mode == updateModeFull {
+				dst.Set(field, dst.NewField(field))
+			}
+			switch {
+			case field.IsList(), field.IsMap():
+				err = updateField(field, dst, src)
+			case field.Message() != nil && !dst.Has(field):
+				err = updateField(field, dst, src)
+			case field.Message() != nil:
+				err = applyUpdate(dst.Get(field).Message(), src.Get(field).Message(), mode)
+			default:
+				err = updateField(field, dst, src)
+			}
+			return err == nil
+		})
 	}
+	return err
+}
+
+func updateField(field protoreflect.FieldDescriptor, dst, src protoreflect.Message) error {
+	if fieldbehavior.Has(field, annotations.FieldBehavior_IMMUTABLE) {
+		if !reflect.DeepEqual(src.Get(field).Interface(), dst.Get(field).Interface()) {
+			return fmt.Errorf("immutable field altered")
+		}
+	}
+	if !src.Has(field) {
+		dst.Clear(field)
+	} else {
+		dst.Set(field, src.Get(field))
+	}
+	return nil
 }


### PR DESCRIPTION
Rewrite fieldmask.Update function by adding logic for handling field behavior.

 https://github.com/einride/aip-go/blob/b48c9c90d8f96bc922e92063be5318e5320cefe1/fieldmask/update.go#L22

I kept the same logic, with specific handling for `OUTPUT_ONLY` and `IMMUTABLE` behaviors :

- `OUTPUT_ONLY` fields are excluded from the update 
- `IMMUTABLE` fields raise an error when the value in dst and src differs

I will try to add new tests regarding these cases.

Fixes #134 