### PR TITLE
feat: generate constructor methods for resource name types

### DIFF
--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/testdata.proto
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/testdata.proto
@@ -4,6 +4,18 @@ package test.single;
 
 import "google/api/resource.proto";
 
+message Shelf {
+  option (google.api.resource) = {
+    type: "test1.testdata/Shelf"
+    singular: "shelf"
+    plural: "shelves"
+    pattern: "shelves/{shelf}"
+  };
+
+  // The resource name of the shelf.
+  string name = 1;
+}
+
 message Book {
   option (google.api.resource) = {
     type: "test1.testdata/Book"

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/testdata_aip.go
@@ -13,9 +13,58 @@ import (
 	strings "strings"
 )
 
+type ShelfResourceName struct {
+	Shelf string
+}
+
+func (n ShelfResourceName) Validate() error {
+	if n.Shelf == "" {
+		return fmt.Errorf("shelf: empty")
+	}
+	if strings.IndexByte(n.Shelf, '/') != -1 {
+		return fmt.Errorf("shelf: contains illegal character '/'")
+	}
+	return nil
+}
+
+func (n ShelfResourceName) ContainsWildcard() bool {
+	return false || n.Shelf == "-"
+}
+
+func (n ShelfResourceName) String() string {
+	return resourcename.Sprint(
+		"shelves/{shelf}",
+		n.Shelf,
+	)
+}
+
+func (n ShelfResourceName) MarshalString() (string, error) {
+	if err := n.Validate(); err != nil {
+		return "", err
+	}
+	return n.String(), nil
+}
+
+func (n *ShelfResourceName) UnmarshalString(name string) error {
+	return resourcename.Sscan(
+		name,
+		"shelves/{shelf}",
+		&n.Shelf,
+	)
+}
+
 type BookResourceName struct {
 	Shelf string
 	Book  string
+}
+
+func (n ShelfResourceName) BookResourceName(
+	book string,
+) BookResourceName {
+	return BookResourceName{
+		Shelf: n.Shelf,
+		Book:  book,
+	}
 }
 
 func (n BookResourceName) Validate() error {
@@ -60,4 +109,10 @@ func (n *BookResourceName) UnmarshalString(name string) error {
 		&n.Shelf,
 		&n.Book,
 	)
+}
+
+func (n BookResourceName) ShelfResourceName() ShelfResourceName {
+	return ShelfResourceName{
+		Shelf: n.Shelf,
+	}
 }

--- a/proto/gen/einride/example/freight/v1/shipment_aip.go
+++ b/proto/gen/einride/example/freight/v1/shipment_aip.go
@@ -18,6 +18,15 @@ type ShipmentResourceName struct {
 	Shipment string
 }
 
+func (n ShipperResourceName) ShipmentResourceName(
+	shipment string,
+) ShipmentResourceName {
+	return ShipmentResourceName{
+		Shipper:  n.Shipper,
+		Shipment: shipment,
+	}
+}
+
 func (n ShipmentResourceName) Validate() error {
 	if n.Shipper == "" {
 		return fmt.Errorf("shipper: empty")

--- a/proto/gen/einride/example/freight/v1/site_aip.go
+++ b/proto/gen/einride/example/freight/v1/site_aip.go
@@ -18,6 +18,15 @@ type SiteResourceName struct {
 	Site    string
 }
 
+func (n ShipperResourceName) SiteResourceName(
+	site string,
+) SiteResourceName {
+	return SiteResourceName{
+		Shipper: n.Shipper,
+		Site:    site,
+	}
+}
+
 func (n SiteResourceName) Validate() error {
 	if n.Shipper == "" {
 		return fmt.Errorf("shipper: empty")


### PR DESCRIPTION
When a resource name has a parent, one often has the parent variable
lying around and the child needs to be created. Instead of having to
repeat all of the fields when constructing the child type, if we have
access to constructor methods that receive the parent struct we can save
some effort.

Before some code might look like:

```
shelf := ShelfResourceName{Shelf: "bottom"}
book := BookResourceName{Shelf: "bottom", Book: "Harry Potter"}
```

Now the code can do this:

```
shelf := ShelfResourceName{Shelf: "bottom"}
book := shelf.BookResourceName("Harry Potter")
```