### PR TITLE
fix: avoid generating single-pattern struct twice

### DIFF
--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/pattern_test.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/pattern_test.go
@@ -1,0 +1,98 @@
+package multipattern
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParseBookMultiPatternResourceName(t *testing.T) {
+	goodPatterns := []string{
+		"shelves/shelf/books/book",
+		"publishers/publisher/books/book",
+	}
+	for _, pattern := range goodPatterns {
+		pattern := pattern
+		t.Run(pattern, func(t *testing.T) {
+			name, err := ParseBookMultiPatternResourceName(pattern)
+			assert.NilError(t, err)
+			assert.Equal(t, name.String(), pattern)
+		})
+	}
+
+	badPatterns := []string{
+		"books/book",
+		"others/other",
+		"others/other/books/book",
+	}
+	for _, pattern := range badPatterns {
+		pattern := pattern
+		t.Run(pattern, func(t *testing.T) {
+			_, err := ParseBookMultiPatternResourceName(pattern)
+			assert.Error(t, err, "no matching pattern")
+		})
+	}
+}
+
+func TestShelvesBookResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const (
+			shelf = "shelf"
+			book  = "book"
+		)
+		pattern := fmt.Sprintf("shelves/%s/books/%s", shelf, book)
+		var name ShelvesBookResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Shelf, shelf)
+		assert.Equal(t, name.Book, book)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("bad top-level", func(t *testing.T) {
+		var name ShelvesBookResourceName
+		err := name.UnmarshalString("books/book")
+		assert.Error(t, err, "parse resource name 'books/book' with pattern 'shelves/{shelf}/books/{book}': segment shelves: got books")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name ShelvesBookResourceName
+		err := name.UnmarshalString("others/other/books/book")
+		assert.Error(t, err, "parse resource name 'others/other/books/book' with pattern 'shelves/{shelf}/books/{book}': segment shelves: got others")
+	})
+}
+
+func TestPublishersBookResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const (
+			publisher = "publisher"
+			book      = "book"
+		)
+		pattern := fmt.Sprintf("publishers/%s/books/%s", publisher, book)
+		var name PublishersBookResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Publisher, publisher)
+		assert.Equal(t, name.Book, book)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("bad top-level", func(t *testing.T) {
+		var name PublishersBookResourceName
+		err := name.UnmarshalString("books/book")
+		assert.Error(t, err, "parse resource name 'books/book' with pattern 'publishers/{publisher}/books/{book}': segment publishers: got books")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name PublishersBookResourceName
+		err := name.UnmarshalString("others/other/books/book")
+		assert.Error(t, err, "parse resource name 'others/other/books/book' with pattern 'publishers/{publisher}/books/{book}': segment publishers: got others")
+	})
+}

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/pattern_test.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/pattern_test.go
@@ -96,3 +96,120 @@ func TestPublishersBookResourceName(t *testing.T) {
 		assert.Error(t, err, "parse resource name 'others/other/books/book' with pattern 'publishers/{publisher}/books/{book}': segment publishers: got others")
 	})
 }
+
+func TestParseShelfMultiPatternResourceName(t *testing.T) {
+	goodPatterns := []string{
+		"shelves/shelf",
+		"libraries/library/shelves/shelf",
+		"rooms/room/shelves/shelf",
+	}
+	for _, pattern := range goodPatterns {
+		pattern := pattern
+		t.Run(pattern, func(t *testing.T) {
+			name, err := ParseShelfMultiPatternResourceName(pattern)
+			assert.NilError(t, err)
+			assert.Equal(t, name.String(), pattern)
+		})
+	}
+
+	badPatterns := []string{
+		"others/other",
+		"others/other/shelves/shelf",
+	}
+	for _, pattern := range badPatterns {
+		pattern := pattern
+		t.Run(pattern, func(t *testing.T) {
+			_, err := ParseShelfMultiPatternResourceName(pattern)
+			assert.Error(t, err, "no matching pattern")
+		})
+	}
+}
+
+func TestShelfResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const shelf = "shelf"
+		pattern := fmt.Sprintf("shelves/%s", shelf)
+		var name ShelfResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Shelf, shelf)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		var name ShelfResourceName
+		err := name.UnmarshalString("others/other")
+		assert.Error(t, err, "parse resource name 'others/other' with pattern 'shelves/{shelf}': segment shelves: got others")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name ShelfResourceName
+		err := name.UnmarshalString("others/other/shelves/shelf")
+		assert.Error(t, err, "parse resource name 'others/other/shelves/shelf' with pattern 'shelves/{shelf}': segment shelves: got others")
+	})
+}
+
+func TestLibrariesShelfResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const (
+			library = "library"
+			shelf   = "shelf"
+		)
+		pattern := fmt.Sprintf("libraries/%s/shelves/%s", library, shelf)
+		var name LibrariesShelfResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Library, library)
+		assert.Equal(t, name.Shelf, shelf)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("bad top-level", func(t *testing.T) {
+		var name LibrariesShelfResourceName
+		err := name.UnmarshalString("books/book")
+		assert.Error(t, err, "parse resource name 'books/book' with pattern 'libraries/{library}/shelves/{shelf}': segment libraries: got books")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name LibrariesShelfResourceName
+		err := name.UnmarshalString("others/other/shelves/shelf")
+		assert.Error(t, err, "parse resource name 'others/other/shelves/shelf' with pattern 'libraries/{library}/shelves/{shelf}': segment libraries: got others")
+	})
+}
+
+func TestRoomsShelfResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const (
+			room  = "room"
+			shelf = "shelf"
+		)
+		pattern := fmt.Sprintf("rooms/%s/shelves/%s", room, shelf)
+		var name RoomsShelfResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Room, room)
+		assert.Equal(t, name.Shelf, shelf)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("bad top-level", func(t *testing.T) {
+		var name RoomsShelfResourceName
+		err := name.UnmarshalString("books/book")
+		assert.Error(t, err, "parse resource name 'books/book' with pattern 'rooms/{room}/shelves/{shelf}': segment rooms: got books")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name RoomsShelfResourceName
+		err := name.UnmarshalString("others/other/shelves/shelf")
+		assert.Error(t, err, "parse resource name 'others/other/shelves/shelf' with pattern 'rooms/{room}/shelves/{shelf}': segment rooms: got others")
+	})
+}

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata.proto
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata.proto
@@ -17,3 +17,19 @@ message Book {
   // The resource name of the book.
   string name = 1;
 }
+
+// Shelf can be either top-level, within a library or within a room.
+message Shelf {
+  option (google.api.resource) = {
+    type: "test1.testdata/Shelf"
+    singular: "shelf"
+    plural: "shelves"
+    pattern: "shelves/{shelf}"
+    pattern: "libraries/{library}/shelves/{shelf}"
+    pattern: "rooms/{room}/shelves/{shelf}"
+    history: FUTURE_MULTI_PATTERN
+  };
+
+  // The resource name.
+  string name = 1;
+}

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
@@ -36,6 +36,15 @@ type ShelvesBookResourceName struct {
 	Book  string
 }
 
+func (n ShelfResourceName) ShelvesBookResourceName(
+	book string,
+) ShelvesBookResourceName {
+	return ShelvesBookResourceName{
+		Shelf: n.Shelf,
+		Book:  book,
+	}
+}
+
 func (n ShelvesBookResourceName) Validate() error {
 	if n.Shelf == "" {
 		return fmt.Errorf("shelf: empty")
@@ -78,6 +87,12 @@ func (n *ShelvesBookResourceName) UnmarshalString(name string) error {
 		&n.Shelf,
 		&n.Book,
 	)
+}
+
+func (n ShelvesBookResourceName) ShelfResourceName() ShelfResourceName {
+	return ShelfResourceName{
+		Shelf: n.Shelf,
+	}
 }
 
 type PublishersBookResourceName struct {
@@ -126,5 +141,164 @@ func (n *PublishersBookResourceName) UnmarshalString(name string) error {
 		"publishers/{publisher}/books/{book}",
 		&n.Publisher,
 		&n.Book,
+	)
+}
+
+type ShelfMultiPatternResourceName interface {
+	fmt.Stringer
+	MarshalString() (string, error)
+}
+
+func ParseShelfMultiPatternResourceName(name string) (ShelfMultiPatternResourceName, error) {
+	switch {
+	case resourcename.Match("shelves/{shelf}", name):
+		var result ShelfResourceName
+		return &result, result.UnmarshalString(name)
+	case resourcename.Match("libraries/{library}/shelves/{shelf}", name):
+		var result LibrariesShelfResourceName
+		return &result, result.UnmarshalString(name)
+	case resourcename.Match("rooms/{room}/shelves/{shelf}", name):
+		var result RoomsShelfResourceName
+		return &result, result.UnmarshalString(name)
+	default:
+		return nil, fmt.Errorf("no matching pattern")
+	}
+}
+
+type ShelfResourceName struct {
+	Shelf string
+}
+
+func (n ShelfResourceName) Validate() error {
+	if n.Shelf == "" {
+		return fmt.Errorf("shelf: empty")
+	}
+	if strings.IndexByte(n.Shelf, '/') != -1 {
+		return fmt.Errorf("shelf: contains illegal character '/'")
+	}
+	return nil
+}
+
+func (n ShelfResourceName) ContainsWildcard() bool {
+	return false || n.Shelf == "-"
+}
+
+func (n ShelfResourceName) String() string {
+	return resourcename.Sprint(
+		"shelves/{shelf}",
+		n.Shelf,
+	)
+}
+
+func (n ShelfResourceName) MarshalString() (string, error) {
+	if err := n.Validate(); err != nil {
+		return "", err
+	}
+	return n.String(), nil
+}
+
+func (n *ShelfResourceName) UnmarshalString(name string) error {
+	return resourcename.Sscan(
+		name,
+		"shelves/{shelf}",
+		&n.Shelf,
+	)
+}
+
+type LibrariesShelfResourceName struct {
+	Library string
+	Shelf   string
+}
+
+func (n LibrariesShelfResourceName) Validate() error {
+	if n.Library == "" {
+		return fmt.Errorf("library: empty")
+	}
+	if strings.IndexByte(n.Library, '/') != -1 {
+		return fmt.Errorf("library: contains illegal character '/'")
+	}
+	if n.Shelf == "" {
+		return fmt.Errorf("shelf: empty")
+	}
+	if strings.IndexByte(n.Shelf, '/') != -1 {
+		return fmt.Errorf("shelf: contains illegal character '/'")
+	}
+	return nil
+}
+
+func (n LibrariesShelfResourceName) ContainsWildcard() bool {
+	return false || n.Library == "-" || n.Shelf == "-"
+}
+
+func (n LibrariesShelfResourceName) String() string {
+	return resourcename.Sprint(
+		"libraries/{library}/shelves/{shelf}",
+		n.Library,
+		n.Shelf,
+	)
+}
+
+func (n LibrariesShelfResourceName) MarshalString() (string, error) {
+	if err := n.Validate(); err != nil {
+		return "", err
+	}
+	return n.String(), nil
+}
+
+func (n *LibrariesShelfResourceName) UnmarshalString(name string) error {
+	return resourcename.Sscan(
+		name,
+		"libraries/{library}/shelves/{shelf}",
+		&n.Library,
+		&n.Shelf,
+	)
+}
+
+type RoomsShelfResourceName struct {
+	Room  string
+	Shelf string
+}
+
+func (n RoomsShelfResourceName) Validate() error {
+	if n.Room == "" {
+		return fmt.Errorf("room: empty")
+	}
+	if strings.IndexByte(n.Room, '/') != -1 {
+		return fmt.Errorf("room: contains illegal character '/'")
+	}
+	if n.Shelf == "" {
+		return fmt.Errorf("shelf: empty")
+	}
+	if strings.IndexByte(n.Shelf, '/') != -1 {
+		return fmt.Errorf("shelf: contains illegal character '/'")
+	}
+	return nil
+}
+
+func (n RoomsShelfResourceName) ContainsWildcard() bool {
+	return false || n.Room == "-" || n.Shelf == "-"
+}
+
+func (n RoomsShelfResourceName) String() string {
+	return resourcename.Sprint(
+		"rooms/{room}/shelves/{shelf}",
+		n.Room,
+		n.Shelf,
+	)
+}
+
+func (n RoomsShelfResourceName) MarshalString() (string, error) {
+	if err := n.Validate(); err != nil {
+		return "", err
+	}
+	return n.String(), nil
+}
+
+func (n *RoomsShelfResourceName) UnmarshalString(name string) error {
+	return resourcename.Sscan(
+		name,
+		"rooms/{room}/shelves/{shelf}",
+		&n.Room,
+		&n.Shelf,
 	)
 }

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/pattern_test.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/pattern_test.go
@@ -1,0 +1,135 @@
+package originallysinglepattern
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParseBookMultiPatternResourceName(t *testing.T) {
+	goodPatterns := []string{
+		"shelves/shelf/books/book",
+		"publishers/publisher/books/book",
+	}
+	for _, pattern := range goodPatterns {
+		pattern := pattern
+		t.Run(pattern, func(t *testing.T) {
+			name, err := ParseBookMultiPatternResourceName(pattern)
+			assert.NilError(t, err)
+			assert.Equal(t, name.String(), pattern)
+		})
+	}
+
+	badPatterns := []string{
+		"books/book",
+		"others/other",
+		"others/other/books/book",
+	}
+	for _, pattern := range badPatterns {
+		pattern := pattern
+		t.Run(pattern, func(t *testing.T) {
+			_, err := ParseBookMultiPatternResourceName(pattern)
+			assert.Error(t, err, "no matching pattern")
+		})
+	}
+}
+
+func TestBookResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const (
+			shelf = "shelf"
+			book  = "book"
+		)
+		pattern := fmt.Sprintf("shelves/%s/books/%s", shelf, book)
+		var name BookResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Shelf, shelf)
+		assert.Equal(t, name.Book, book)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("bad top-level", func(t *testing.T) {
+		var name BookResourceName
+		err := name.UnmarshalString("books/book")
+		assert.Error(t, err, "parse resource name 'books/book' with pattern 'shelves/{shelf}/books/{book}': segment shelves: got books")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name BookResourceName
+		err := name.UnmarshalString("others/other/books/book")
+		assert.Error(t, err, "parse resource name 'others/other/books/book' with pattern 'shelves/{shelf}/books/{book}': segment shelves: got others")
+	})
+
+	t.Run("bad newer parent", func(t *testing.T) {
+		var name BookResourceName
+		err := name.UnmarshalString("publishers/publisher/books/book")
+		assert.Error(t, err, "parse resource name 'publishers/publisher/books/book' with pattern 'shelves/{shelf}/books/{book}': segment shelves: got publishers")
+	})
+}
+
+func TestShelvesBookResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const (
+			shelf = "shelf"
+			book  = "book"
+		)
+		pattern := fmt.Sprintf("shelves/%s/books/%s", shelf, book)
+		var name ShelvesBookResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Shelf, shelf)
+		assert.Equal(t, name.Book, book)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("bad top-level", func(t *testing.T) {
+		var name ShelvesBookResourceName
+		err := name.UnmarshalString("books/book")
+		assert.Error(t, err, "parse resource name 'books/book' with pattern 'shelves/{shelf}/books/{book}': segment shelves: got books")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name ShelvesBookResourceName
+		err := name.UnmarshalString("others/other/books/book")
+		assert.Error(t, err, "parse resource name 'others/other/books/book' with pattern 'shelves/{shelf}/books/{book}': segment shelves: got others")
+	})
+}
+
+func TestPublishersBookResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const (
+			publisher = "publisher"
+			book      = "book"
+		)
+		pattern := fmt.Sprintf("publishers/%s/books/%s", publisher, book)
+		var name PublishersBookResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Publisher, publisher)
+		assert.Equal(t, name.Book, book)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("bad top-level", func(t *testing.T) {
+		var name PublishersBookResourceName
+		err := name.UnmarshalString("books/book")
+		assert.Error(t, err, "parse resource name 'books/book' with pattern 'publishers/{publisher}/books/{book}': segment publishers: got books")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name PublishersBookResourceName
+		err := name.UnmarshalString("others/other/books/book")
+		assert.Error(t, err, "parse resource name 'others/other/books/book' with pattern 'publishers/{publisher}/books/{book}': segment publishers: got others")
+	})
+}

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/pattern_test.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/pattern_test.go
@@ -133,3 +133,92 @@ func TestPublishersBookResourceName(t *testing.T) {
 		assert.Error(t, err, "parse resource name 'others/other/books/book' with pattern 'publishers/{publisher}/books/{book}': segment publishers: got others")
 	})
 }
+
+func TestShelfResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const shelf = "shelf"
+		pattern := fmt.Sprintf("shelves/%s", shelf)
+		var name ShelfResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Shelf, shelf)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		var name ShelfResourceName
+		err := name.UnmarshalString("others/other")
+		assert.Error(t, err, "parse resource name 'others/other' with pattern 'shelves/{shelf}': segment shelves: got others")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name ShelfResourceName
+		err := name.UnmarshalString("others/other/shelves/shelf")
+		assert.Error(t, err, "parse resource name 'others/other/shelves/shelf' with pattern 'shelves/{shelf}': segment shelves: got others")
+	})
+}
+
+func TestLibrariesShelfResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const (
+			library = "library"
+			shelf   = "shelf"
+		)
+		pattern := fmt.Sprintf("libraries/%s/shelves/%s", library, shelf)
+		var name LibrariesShelfResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Library, library)
+		assert.Equal(t, name.Shelf, shelf)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("bad top-level", func(t *testing.T) {
+		var name LibrariesShelfResourceName
+		err := name.UnmarshalString("books/book")
+		assert.Error(t, err, "parse resource name 'books/book' with pattern 'libraries/{library}/shelves/{shelf}': segment libraries: got books")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name LibrariesShelfResourceName
+		err := name.UnmarshalString("others/other/shelves/shelf")
+		assert.Error(t, err, "parse resource name 'others/other/shelves/shelf' with pattern 'libraries/{library}/shelves/{shelf}': segment libraries: got others")
+	})
+}
+
+func TestRoomsShelfResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const (
+			room  = "room"
+			shelf = "shelf"
+		)
+		pattern := fmt.Sprintf("rooms/%s/shelves/%s", room, shelf)
+		var name RoomsShelfResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Room, room)
+		assert.Equal(t, name.Shelf, shelf)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("bad top-level", func(t *testing.T) {
+		var name RoomsShelfResourceName
+		err := name.UnmarshalString("books/book")
+		assert.Error(t, err, "parse resource name 'books/book' with pattern 'rooms/{room}/shelves/{shelf}': segment rooms: got books")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name RoomsShelfResourceName
+		err := name.UnmarshalString("others/other/shelves/shelf")
+		assert.Error(t, err, "parse resource name 'others/other/shelves/shelf' with pattern 'rooms/{room}/shelves/{shelf}': segment rooms: got others")
+	})
+}

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata.proto
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata.proto
@@ -17,3 +17,19 @@ message Book {
   // The resource name of the book.
   string name = 1;
 }
+
+// Shelf can be either top-level, within a library or within a room.
+message Shelf {
+  option (google.api.resource) = {
+    type: "test1.testdata/Shelf"
+    singular: "shelf"
+    plural: "shelves"
+    pattern: "shelves/{shelf}"
+    pattern: "libraries/{library}/shelves/{shelf}"
+    pattern: "rooms/{room}/shelves/{shelf}"
+    history: ORIGINALLY_SINGLE_PATTERN
+  };
+
+  // The resource name.
+  string name = 1;
+}

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
@@ -36,6 +36,15 @@ type BookResourceName struct {
 	Book  string
 }
 
+func (n ShelfResourceName) BookResourceName(
+	book string,
+) BookResourceName {
+	return BookResourceName{
+		Shelf: n.Shelf,
+		Book:  book,
+	}
+}
+
 func (n BookResourceName) Validate() error {
 	if n.Shelf == "" {
 		return fmt.Errorf("shelf: empty")
@@ -80,9 +89,24 @@ func (n *BookResourceName) UnmarshalString(name string) error {
 	)
 }
 
+func (n BookResourceName) ShelfResourceName() ShelfResourceName {
+	return ShelfResourceName{
+		Shelf: n.Shelf,
+	}
+}
+
 type ShelvesBookResourceName struct {
 	Shelf string
 	Book  string
+}
+
+func (n ShelfResourceName) ShelvesBookResourceName(
+	book string,
+) ShelvesBookResourceName {
+	return ShelvesBookResourceName{
+		Shelf: n.Shelf,
+		Book:  book,
+	}
 }
 
 func (n ShelvesBookResourceName) Validate() error {
@@ -127,6 +151,12 @@ func (n *ShelvesBookResourceName) UnmarshalString(name string) error {
 		&n.Shelf,
 		&n.Book,
 	)
+}
+
+func (n ShelvesBookResourceName) ShelfResourceName() ShelfResourceName {
+	return ShelfResourceName{
+		Shelf: n.Shelf,
+	}
 }
 
 type PublishersBookResourceName struct {
@@ -175,5 +205,164 @@ func (n *PublishersBookResourceName) UnmarshalString(name string) error {
 		"publishers/{publisher}/books/{book}",
 		&n.Publisher,
 		&n.Book,
+	)
+}
+
+type ShelfMultiPatternResourceName interface {
+	fmt.Stringer
+	MarshalString() (string, error)
+}
+
+func ParseShelfMultiPatternResourceName(name string) (ShelfMultiPatternResourceName, error) {
+	switch {
+	case resourcename.Match("shelves/{shelf}", name):
+		var result ShelfResourceName
+		return &result, result.UnmarshalString(name)
+	case resourcename.Match("libraries/{library}/shelves/{shelf}", name):
+		var result LibrariesShelfResourceName
+		return &result, result.UnmarshalString(name)
+	case resourcename.Match("rooms/{room}/shelves/{shelf}", name):
+		var result RoomsShelfResourceName
+		return &result, result.UnmarshalString(name)
+	default:
+		return nil, fmt.Errorf("no matching pattern")
+	}
+}
+
+type ShelfResourceName struct {
+	Shelf string
+}
+
+func (n ShelfResourceName) Validate() error {
+	if n.Shelf == "" {
+		return fmt.Errorf("shelf: empty")
+	}
+	if strings.IndexByte(n.Shelf, '/') != -1 {
+		return fmt.Errorf("shelf: contains illegal character '/'")
+	}
+	return nil
+}
+
+func (n ShelfResourceName) ContainsWildcard() bool {
+	return false || n.Shelf == "-"
+}
+
+func (n ShelfResourceName) String() string {
+	return resourcename.Sprint(
+		"shelves/{shelf}",
+		n.Shelf,
+	)
+}
+
+func (n ShelfResourceName) MarshalString() (string, error) {
+	if err := n.Validate(); err != nil {
+		return "", err
+	}
+	return n.String(), nil
+}
+
+func (n *ShelfResourceName) UnmarshalString(name string) error {
+	return resourcename.Sscan(
+		name,
+		"shelves/{shelf}",
+		&n.Shelf,
+	)
+}
+
+type LibrariesShelfResourceName struct {
+	Library string
+	Shelf   string
+}
+
+func (n LibrariesShelfResourceName) Validate() error {
+	if n.Library == "" {
+		return fmt.Errorf("library: empty")
+	}
+	if strings.IndexByte(n.Library, '/') != -1 {
+		return fmt.Errorf("library: contains illegal character '/'")
+	}
+	if n.Shelf == "" {
+		return fmt.Errorf("shelf: empty")
+	}
+	if strings.IndexByte(n.Shelf, '/') != -1 {
+		return fmt.Errorf("shelf: contains illegal character '/'")
+	}
+	return nil
+}
+
+func (n LibrariesShelfResourceName) ContainsWildcard() bool {
+	return false || n.Library == "-" || n.Shelf == "-"
+}
+
+func (n LibrariesShelfResourceName) String() string {
+	return resourcename.Sprint(
+		"libraries/{library}/shelves/{shelf}",
+		n.Library,
+		n.Shelf,
+	)
+}
+
+func (n LibrariesShelfResourceName) MarshalString() (string, error) {
+	if err := n.Validate(); err != nil {
+		return "", err
+	}
+	return n.String(), nil
+}
+
+func (n *LibrariesShelfResourceName) UnmarshalString(name string) error {
+	return resourcename.Sscan(
+		name,
+		"libraries/{library}/shelves/{shelf}",
+		&n.Library,
+		&n.Shelf,
+	)
+}
+
+type RoomsShelfResourceName struct {
+	Room  string
+	Shelf string
+}
+
+func (n RoomsShelfResourceName) Validate() error {
+	if n.Room == "" {
+		return fmt.Errorf("room: empty")
+	}
+	if strings.IndexByte(n.Room, '/') != -1 {
+		return fmt.Errorf("room: contains illegal character '/'")
+	}
+	if n.Shelf == "" {
+		return fmt.Errorf("shelf: empty")
+	}
+	if strings.IndexByte(n.Shelf, '/') != -1 {
+		return fmt.Errorf("shelf: contains illegal character '/'")
+	}
+	return nil
+}
+
+func (n RoomsShelfResourceName) ContainsWildcard() bool {
+	return false || n.Room == "-" || n.Shelf == "-"
+}
+
+func (n RoomsShelfResourceName) String() string {
+	return resourcename.Sprint(
+		"rooms/{room}/shelves/{shelf}",
+		n.Room,
+		n.Shelf,
+	)
+}
+
+func (n RoomsShelfResourceName) MarshalString() (string, error) {
+	if err := n.Validate(); err != nil {
+		return "", err
+	}
+	return n.String(), nil
+}
+
+func (n *RoomsShelfResourceName) UnmarshalString(name string) error {
+	return resourcename.Sscan(
+		name,
+		"rooms/{room}/shelves/{shelf}",
+		&n.Room,
+		&n.Shelf,
 	)
 }

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/pattern_test.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/pattern_test.go
@@ -1,0 +1,66 @@
+package single
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestBookResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const (
+			shelf = "shelf"
+			book  = "book"
+		)
+		pattern := fmt.Sprintf("shelves/%s/books/%s", shelf, book)
+		var name BookResourceName
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Shelf, shelf)
+		assert.Equal(t, name.Book, book)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("bad top-level", func(t *testing.T) {
+		var name BookResourceName
+		err := name.UnmarshalString("books/book")
+		assert.Error(t, err, "parse resource name 'books/book' with pattern 'shelves/{shelf}/books/{book}': segment shelves: got books")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		var name BookResourceName
+		err := name.UnmarshalString("others/other/books/book")
+		assert.Error(t, err, "parse resource name 'others/other/books/book' with pattern 'shelves/{shelf}/books/{book}': segment shelves: got others")
+	})
+}
+
+func TestShelfResourceName(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		const shelf = "shelf"
+		pattern := fmt.Sprintf("shelves/%s", shelf)
+		name := ShelfResourceName{}
+		err := name.UnmarshalString(pattern)
+		assert.NilError(t, err)
+		assert.Equal(t, name.Shelf, shelf)
+
+		marshalled, err := name.MarshalString()
+		assert.NilError(t, err)
+		assert.Equal(t, marshalled, pattern)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		name := ShelfResourceName{}
+		err := name.UnmarshalString(fmt.Sprintf("others/other"))
+		assert.Error(t, err, "parse resource name 'others/other' with pattern 'shelves/{shelf}': segment shelves: got others")
+	})
+
+	t.Run("bad wrong parent", func(t *testing.T) {
+		name := ShelfResourceName{}
+		err := name.UnmarshalString(fmt.Sprintf("others/other/shelves/shelf"))
+		assert.Error(t, err, "parse resource name 'others/other/shelves/shelf' with pattern 'shelves/{shelf}': segment shelves: got others")
+	})
+}

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/pattern_test.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/pattern_test.go
@@ -42,7 +42,7 @@ func TestShelfResourceName(t *testing.T) {
 	t.Run("good", func(t *testing.T) {
 		const shelf = "shelf"
 		pattern := fmt.Sprintf("shelves/%s", shelf)
-		name := ShelfResourceName{}
+		var name ShelfResourceName
 		err := name.UnmarshalString(pattern)
 		assert.NilError(t, err)
 		assert.Equal(t, name.Shelf, shelf)
@@ -53,14 +53,14 @@ func TestShelfResourceName(t *testing.T) {
 	})
 
 	t.Run("invalid", func(t *testing.T) {
-		name := ShelfResourceName{}
-		err := name.UnmarshalString(fmt.Sprintf("others/other"))
+		var name ShelfResourceName
+		err := name.UnmarshalString("others/other")
 		assert.Error(t, err, "parse resource name 'others/other' with pattern 'shelves/{shelf}': segment shelves: got others")
 	})
 
 	t.Run("bad wrong parent", func(t *testing.T) {
-		name := ShelfResourceName{}
-		err := name.UnmarshalString(fmt.Sprintf("others/other/shelves/shelf"))
+		var name ShelfResourceName
+		err := name.UnmarshalString("others/other/shelves/shelf")
 		assert.Error(t, err, "parse resource name 'others/other/shelves/shelf' with pattern 'shelves/{shelf}': segment shelves: got others")
 	})
 }


### PR DESCRIPTION
For top-level resources, multi-pattern resource names causes the generation of two identical structs as the multi-pattern struct of the first pattern is identical to the single-pattern struct.

See added Shelf resources and accompanying test cases which reproduces the issue without the fix.

To validate this doesn't break existing behavior, the first commit introduces some regression tests.