### PR TITLE
fix: respect pagination skip field

### DIFF
--- a/pagination/pagetoken.go
+++ b/pagination/pagetoken.go
@@ -32,8 +32,12 @@ func ParsePageToken(request Request) (_ PageToken, err error) {
 	}
 	requestChecksum ^= pageTokenChecksumMask // apply checksum mask for PageToken
 	if request.GetPageToken() == "" {
+		offset := int64(0)
+		if s, ok := request.(skipRequest); ok {
+			offset += int64(s.GetSkip())
+		}
 		return PageToken{
-			Offset:          0,
+			Offset:          offset,
 			RequestChecksum: requestChecksum,
 		}, nil
 	}
@@ -45,6 +49,9 @@ func ParsePageToken(request Request) (_ PageToken, err error) {
 		return PageToken{}, fmt.Errorf(
 			"checksum mismatch (got 0x%x but expected 0x%x)", pageToken.RequestChecksum, requestChecksum,
 		)
+	}
+	if s, ok := request.(skipRequest); ok {
+		pageToken.Offset += int64(s.GetSkip())
 	}
 	return pageToken, nil
 }

--- a/pagination/pagetoken_test.go
+++ b/pagination/pagetoken_test.go
@@ -3,6 +3,7 @@ package pagination
 import (
 	"testing"
 
+	freightv1 "go.einride.tech/aip/proto/gen/einride/example/freight/v1"
 	"google.golang.org/genproto/googleapis/example/library/v1"
 	"gotest.tools/v3/assert"
 )
@@ -34,7 +35,58 @@ func TestParseOffsetPageToken(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, int64(30), pageToken3.Offset)
 	})
-
+	t.Run("skip", func(t *testing.T) {
+		t.Run("handle empty token with skip", func(t *testing.T) {
+			request1 := &freightv1.ListSitesRequest{
+				Parent:   "shippers/1",
+				Skip:     30,
+				PageSize: 20,
+			}
+			pageToken1, err := ParsePageToken(request1)
+			assert.NilError(t, err)
+			assert.Equal(t, int64(30), pageToken1.Offset)
+		})
+		t.Run("handle existing token with another skip", func(t *testing.T) {
+			request1 := &freightv1.ListSitesRequest{
+				Parent:   "shippers/1",
+				Skip:     50,
+				PageSize: 20,
+			}
+			pageToken1, err := ParsePageToken(request1)
+			assert.NilError(t, err)
+			assert.Equal(t, int64(50), pageToken1.Offset)
+			request2 := &freightv1.ListSitesRequest{
+				Parent:    "shippers/1",
+				Skip:      30,
+				PageSize:  0,
+				PageToken: pageToken1.String(),
+			}
+			pageToken2, err := ParsePageToken(request2)
+			assert.NilError(t, err)
+			pageToken3 := pageToken2.Next(request2)
+			assert.Equal(t, int64(80), pageToken3.Offset)
+		})
+		t.Run("handle existing token with pagesize and skip", func(t *testing.T) {
+			request1 := &freightv1.ListSitesRequest{
+				Parent:   "shippers/1",
+				Skip:     50,
+				PageSize: 20,
+			}
+			pageToken1, err := ParsePageToken(request1)
+			assert.NilError(t, err)
+			assert.Equal(t, int64(50), pageToken1.Offset)
+			request2 := &freightv1.ListSitesRequest{
+				Parent:    "shippers/1",
+				Skip:      30,
+				PageSize:  20,
+				PageToken: pageToken1.String(),
+			}
+			pageToken2, err := ParsePageToken(request2)
+			assert.NilError(t, err)
+			pageToken3 := pageToken2.Next(request2)
+			assert.Equal(t, int64(100), pageToken3.Offset)
+		})
+	})
 	t.Run("invalid format", func(t *testing.T) {
 		t.Parallel()
 		request := &library.ListBooksRequest{


### PR DESCRIPTION
BREAKING CHANGE: This will result in a different response if
next_page_token have been used in combination with skip.
