### PR TITLE
fix(resourcename): disallow leading single slash

### DIFF
--- a/resourcename/matches_test.go
+++ b/resourcename/matches_test.go
@@ -75,14 +75,21 @@ func TestMatches(t *testing.T) {
 			test:     "slash prefix in the name",
 			name:     "/shippers/1",
 			pattern:  "shippers/{shipper}",
-			expected: true,
+			expected: false,
 		},
 
 		{
 			test:     "slash prefix in the pattern",
 			name:     "shippers/1",
 			pattern:  "/shippers/{shipper}",
-			expected: true,
+			expected: false,
+		},
+
+		{
+			test:     "root",
+			name:     "/",
+			pattern:  "/",
+			expected: false,
 		},
 	} {
 		tt := tt

--- a/resourcename/scanner.go
+++ b/resourcename/scanner.go
@@ -21,6 +21,9 @@ func (s *Scanner) Init(name string) {
 
 // Scan to the next segment.
 func (s *Scanner) Scan() bool {
+	if s.name == "/" {
+		return false
+	}
 	switch s.end {
 	case len(s.name):
 		return false
@@ -37,8 +40,6 @@ func (s *Scanner) Scan() bool {
 			}
 			s.serviceStart, s.serviceEnd = s.start, s.start+nextSlash
 			s.start, s.end = s.start+nextSlash+1, s.start+nextSlash+1
-		} else if strings.HasPrefix(s.name, "/") {
-			s.start = s.end + 1 // start past beginning slash
 		}
 	default:
 		s.start = s.end + 1 // start past latest slash

--- a/resourcename/scanner_test.go
+++ b/resourcename/scanner_test.go
@@ -58,6 +58,12 @@ func TestSegmentScanner(t *testing.T) {
 		},
 
 		{
+			name:     "root",
+			input:    "/",
+			segments: []Segment{},
+		},
+
+		{
 			name:        "full",
 			input:       "//library.googleapis.com/publishers/123/books/les-miserables",
 			full:        true,

--- a/resourcename/validate_test.go
+++ b/resourcename/validate_test.go
@@ -38,6 +38,12 @@ func TestValidate(t *testing.T) {
 		},
 
 		{
+			name:          "invalid slash prefix",
+			input:         "/foo/bar",
+			errorContains: "segment 1 is empty",
+		},
+
+		{
 			name:          "variable",
 			input:         "foo/bar/{baz}",
 			errorContains: "must not contain variables",
@@ -86,6 +92,11 @@ func TestValidate(t *testing.T) {
 		{
 			name:  "full",
 			input: "//example.com/foo/bar",
+		},
+
+		{
+			name:  "root",
+			input: "/",
 		},
 	} {
 		tt := tt


### PR DESCRIPTION
This shouldn't be allowed according to AIP-122 and we should reject it.

Unsure how much of a breaking change it would be, so I'm not fully sure we want to merge it. Let me know what you think!

It somewhat reverts #103