### PR TITLE
feat(protoc): expose ContainsWildcard on multipattern

### DIFF
--- a/cmd/protoc-gen-go-aip/internal/genaip/resourcename.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/resourcename.go
@@ -353,6 +353,7 @@ func (r resourceNameCodeGenerator) generateMultiPatternInterface(g *protogen.Gen
 	g.P("type ", r.MultiPatternInterfaceName(), " interface {")
 	g.P(fmtStringer)
 	g.P("MarshalString() (string, error)")
+	g.P("ContainsWildcard() bool")
 	g.P("}")
 	return nil
 }

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
@@ -16,6 +16,7 @@ import (
 type BookMultiPatternResourceName interface {
 	fmt.Stringer
 	MarshalString() (string, error)
+	ContainsWildcard() bool
 }
 
 func ParseBookMultiPatternResourceName(name string) (BookMultiPatternResourceName, error) {
@@ -147,6 +148,7 @@ func (n *PublishersBookResourceName) UnmarshalString(name string) error {
 type ShelfMultiPatternResourceName interface {
 	fmt.Stringer
 	MarshalString() (string, error)
+	ContainsWildcard() bool
 }
 
 func ParseShelfMultiPatternResourceName(name string) (ShelfMultiPatternResourceName, error) {

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
@@ -16,6 +16,7 @@ import (
 type BookMultiPatternResourceName interface {
 	fmt.Stringer
 	MarshalString() (string, error)
+	ContainsWildcard() bool
 }
 
 func ParseBookMultiPatternResourceName(name string) (BookMultiPatternResourceName, error) {
@@ -211,6 +212,7 @@ func (n *PublishersBookResourceName) UnmarshalString(name string) error {
 type ShelfMultiPatternResourceName interface {
 	fmt.Stringer
 	MarshalString() (string, error)
+	ContainsWildcard() bool
 }
 
 func ParseShelfMultiPatternResourceName(name string) (ShelfMultiPatternResourceName, error) {


### PR DESCRIPTION
Resource name structs have a ContainsWildcard() method. To simplify checking this on multi-pattern resource names, exposing this on the multipattern interface makes it easy to check without figuring out the underlying type first.