### PR TITLE
fix(fieldmask): traverse repeated fields with wildcard in validation

### DIFF
--- a/fieldmask/update_test.go
+++ b/fieldmask/update_test.go
@@ -430,7 +430,7 @@ func TestUpdate(t *testing.T) {
 				// can not update individual fields in a repeated message
 				name: "repeated message: deep",
 				paths: []string{
-					"repeated_message.string",
+					"repeated_message.*.string",
 				},
 				src: &syntaxv1.Message{
 					RepeatedMessage: []*syntaxv1.Message{

--- a/fieldmask/validate_test.go
+++ b/fieldmask/validate_test.go
@@ -3,6 +3,7 @@ package fieldmask
 import (
 	"testing"
 
+	freightv1 "go.einride.tech/aip/proto/gen/einride/example/freight/v1"
 	"google.golang.org/genproto/googleapis/example/library/v1"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -70,6 +71,23 @@ func TestValidate(t *testing.T) {
 			},
 			message:       &library.CreateBookRequest{},
 			errorContains: "invalid field path: book.foo",
+		},
+
+		{
+			name: "invalid nested in repeated field",
+			fieldMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"shipment.line_items.title"},
+			},
+			message:       &freightv1.CreateShipmentRequest{},
+			errorContains: "invalid field path: shipment.line_items.title",
+		},
+
+		{
+			name: "valid nested in repeated field",
+			fieldMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"shipment.line_items.*.title"},
+			},
+			message: &freightv1.CreateShipmentRequest{},
 		},
 	} {
 		tt := tt


### PR DESCRIPTION
`fieldmask.Validate` incorrectly allows targeting of subfields on repeated fields as 
```
repeated.subfield
``` 
whereas [AIP161](https://google.aip.dev/161#wildcards) specifies that targeting of subfields **_MAY_** be added using wildcards as a suffix to the repeated field, such as:
```
repeated.*.subfield
```

This PR proposes to allow traversing repeated fields with the use of wildcard `*` when validating a fieldmask.

Note that the targeting subfields on repeated fields is not handled in [`fieldmask.Update`](https://github.com/einride/aip-go/blob/master/fieldmask/update.go#L89-L91). 
```
...
case field.IsList(), field.IsMap():
	// nested fields in repeated or map not supported
	return
...
```