### PR TITLE
Filtering Declaration Options for Constants

### DIFF
--- a/filtering/checker_test.go
+++ b/filtering/checker_test.go
@@ -3,8 +3,10 @@ package filtering
 import (
 	"testing"
 
-	syntaxv1 "go.einride.tech/aip/proto/gen/einride/example/syntax/v1"
+	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	"gotest.tools/v3/assert"
+
+	syntaxv1 "go.einride.tech/aip/proto/gen/einride/example/syntax/v1"
 )
 
 func TestChecker(t *testing.T) {
@@ -410,6 +412,88 @@ func TestChecker(t *testing.T) {
 				DeclareStandardFunctions(),
 				DeclareIdent("create_time", TypeTimestamp),
 			},
+		},
+
+		{
+			filter: "IsGreat = true",
+			declarations: []DeclarationOption{
+				DeclareStandardFunctions(),
+				DeclareIdent("IsGreat", TypeBool),
+				DeclareConstant("true", TypeBool, &expr.Constant{ConstantKind: &expr.Constant_BoolValue{BoolValue: true}}),
+			},
+		},
+
+		{
+			filter: "IsGreat = true",
+			declarations: []DeclarationOption{
+				DeclareStandardFunctions(),
+				DeclareStandardBoolConstants(),
+				DeclareIdent("IsGreat", TypeBool),
+			},
+		},
+
+		{
+			filter: "IsGreat = True",
+			declarations: []DeclarationOption{
+				DeclareStandardFunctions(),
+				DeclareStandardBoolConstants(),
+				DeclareIdent("IsGreat", TypeBool),
+			},
+		},
+
+		{
+			filter: "IsGreat = TRUE",
+			declarations: []DeclarationOption{
+				DeclareStandardFunctions(),
+				DeclareStandardBoolConstants(),
+				DeclareIdent("IsGreat", TypeBool),
+			},
+		},
+
+		{
+			filter: "IsGreat = false",
+			declarations: []DeclarationOption{
+				DeclareStandardFunctions(),
+				DeclareIdent("IsGreat", TypeBool),
+				DeclareConstant("false", TypeBool, &expr.Constant{ConstantKind: &expr.Constant_BoolValue{BoolValue: true}}),
+			},
+		},
+
+		{
+			filter: "IsGreat = false",
+			declarations: []DeclarationOption{
+				DeclareStandardFunctions(),
+				DeclareStandardBoolConstants(),
+				DeclareIdent("IsGreat", TypeBool),
+			},
+		},
+
+		{
+			filter: "IsGreat = False",
+			declarations: []DeclarationOption{
+				DeclareStandardFunctions(),
+				DeclareStandardBoolConstants(),
+				DeclareIdent("IsGreat", TypeBool),
+			},
+		},
+
+		{
+			filter: "IsGreat = FALSE",
+			declarations: []DeclarationOption{
+				DeclareStandardFunctions(),
+				DeclareStandardBoolConstants(),
+				DeclareIdent("IsGreat", TypeBool),
+			},
+		},
+
+		{
+			filter: "IsGreat = FalsE",
+			declarations: []DeclarationOption{
+				DeclareStandardFunctions(),
+				DeclareStandardBoolConstants(),
+				DeclareIdent("IsGreat", TypeBool),
+			},
+			errorContains: "undeclared identifier 'FalsE'",
 		},
 
 		{

--- a/filtering/declarations.go
+++ b/filtering/declarations.go
@@ -73,11 +73,30 @@ type Declarations struct {
 // DeclarationOption configures Declarations.
 type DeclarationOption func(*Declarations) error
 
-// DeclareStandardFunction is a DeclarationOption that declares all standard functions and their overloads.
+// DeclareStandardFunctions is a DeclarationOption that declares all standard functions and their overloads.
 func DeclareStandardFunctions() DeclarationOption {
 	return func(declarations *Declarations) error {
 		for _, declaration := range StandardFunctionDeclarations() {
 			if err := declarations.declare(declaration); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// DeclareStandardBoolConstants is a DeclarationOption that adds a number of variations of "true" and "false" as constant values.
+func DeclareStandardBoolConstants() DeclarationOption {
+	return func(declarations *Declarations) error {
+		for n, v := range map[string]bool{
+			"true":  true,
+			"True":  true,
+			"TRUE":  true,
+			"false": false,
+			"False": false,
+			"FALSE": false,
+		} {
+			if err := declarations.declareConstant(n, TypeBool, &expr.Constant{ConstantKind: &expr.Constant_BoolValue{BoolValue: v}}); err != nil {
 				return err
 			}
 		}
@@ -99,9 +118,17 @@ func DeclareIdent(name string, t *expr.Type) DeclarationOption {
 	}
 }
 
+// DeclareEnumIdent is a DeclarationOption that declares an enumeration.
 func DeclareEnumIdent(name string, enumType protoreflect.EnumType) DeclarationOption {
 	return func(declarations *Declarations) error {
 		return declarations.declareEnumIdent(name, enumType)
+	}
+}
+
+// DeclareConstant is a DeclarationOption that adds a constant value to the declarations.
+func DeclareConstant(name string, constantType *expr.Type, constantValue *expr.Constant) DeclarationOption {
+	return func(declarations *Declarations) error {
+		return declarations.declareConstant(name, constantType, constantValue)
 	}
 }
 


### PR DESCRIPTION
Add various filtering declaration options for constant values, including a specific helper for true/false booleans.