### PR TITLE
Call Validate() when unmarshalling resource name

### DIFF
--- a/cmd/protoc-gen-go-aip/internal/genaip/resourcename.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/resourcename.go
@@ -329,7 +329,7 @@ func (r resourceNameCodeGenerator) generateUnmarshalStringMethod(
 	})
 	g.P()
 	g.P("func (n *", typeName, ") UnmarshalString(name string) error {")
-	g.P("return ", resourcenameSscan, "(")
+	g.P("err := ", resourcenameSscan, "(")
 	g.P("name,")
 	g.P(strconv.Quote(pattern), ",")
 	var sc resourcename.Scanner
@@ -340,6 +340,10 @@ func (r resourceNameCodeGenerator) generateUnmarshalStringMethod(
 		}
 	}
 	g.P(")")
+	g.P("if err != nil {")
+	g.P("return err")
+	g.P("}")
+	g.P("return n.Validate()")
 	g.P("}")
 	return nil
 }

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
@@ -82,12 +82,16 @@ func (n ShelvesBookResourceName) MarshalString() (string, error) {
 }
 
 func (n *ShelvesBookResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"shelves/{shelf}/books/{book}",
 		&n.Shelf,
 		&n.Book,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 func (n ShelvesBookResourceName) ShelfResourceName() ShelfResourceName {
@@ -137,12 +141,16 @@ func (n PublishersBookResourceName) MarshalString() (string, error) {
 }
 
 func (n *PublishersBookResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"publishers/{publisher}/books/{book}",
 		&n.Publisher,
 		&n.Book,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 type ShelfMultiPatternResourceName interface {
@@ -200,11 +208,15 @@ func (n ShelfResourceName) MarshalString() (string, error) {
 }
 
 func (n *ShelfResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"shelves/{shelf}",
 		&n.Shelf,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 type LibrariesShelfResourceName struct {
@@ -248,12 +260,16 @@ func (n LibrariesShelfResourceName) MarshalString() (string, error) {
 }
 
 func (n *LibrariesShelfResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"libraries/{library}/shelves/{shelf}",
 		&n.Library,
 		&n.Shelf,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 type RoomsShelfResourceName struct {
@@ -297,10 +313,14 @@ func (n RoomsShelfResourceName) MarshalString() (string, error) {
 }
 
 func (n *RoomsShelfResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"rooms/{room}/shelves/{shelf}",
 		&n.Room,
 		&n.Shelf,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
@@ -82,12 +82,16 @@ func (n BookResourceName) MarshalString() (string, error) {
 }
 
 func (n *BookResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"shelves/{shelf}/books/{book}",
 		&n.Shelf,
 		&n.Book,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 func (n BookResourceName) ShelfResourceName() ShelfResourceName {
@@ -146,12 +150,16 @@ func (n ShelvesBookResourceName) MarshalString() (string, error) {
 }
 
 func (n *ShelvesBookResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"shelves/{shelf}/books/{book}",
 		&n.Shelf,
 		&n.Book,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 func (n ShelvesBookResourceName) ShelfResourceName() ShelfResourceName {
@@ -201,12 +209,16 @@ func (n PublishersBookResourceName) MarshalString() (string, error) {
 }
 
 func (n *PublishersBookResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"publishers/{publisher}/books/{book}",
 		&n.Publisher,
 		&n.Book,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 type ShelfMultiPatternResourceName interface {
@@ -264,11 +276,15 @@ func (n ShelfResourceName) MarshalString() (string, error) {
 }
 
 func (n *ShelfResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"shelves/{shelf}",
 		&n.Shelf,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 type LibrariesShelfResourceName struct {
@@ -312,12 +328,16 @@ func (n LibrariesShelfResourceName) MarshalString() (string, error) {
 }
 
 func (n *LibrariesShelfResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"libraries/{library}/shelves/{shelf}",
 		&n.Library,
 		&n.Shelf,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 type RoomsShelfResourceName struct {
@@ -361,10 +381,14 @@ func (n RoomsShelfResourceName) MarshalString() (string, error) {
 }
 
 func (n *RoomsShelfResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"rooms/{room}/shelves/{shelf}",
 		&n.Room,
 		&n.Shelf,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/testdata_aip.go
@@ -46,11 +46,15 @@ func (n ShelfResourceName) MarshalString() (string, error) {
 }
 
 func (n *ShelfResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"shelves/{shelf}",
 		&n.Shelf,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 type BookResourceName struct {
@@ -103,12 +107,16 @@ func (n BookResourceName) MarshalString() (string, error) {
 }
 
 func (n *BookResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"shelves/{shelf}/books/{book}",
 		&n.Shelf,
 		&n.Book,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 func (n BookResourceName) ShelfResourceName() ShelfResourceName {

--- a/proto/gen/einride/example/freight/v1/shipment_aip.go
+++ b/proto/gen/einride/example/freight/v1/shipment_aip.go
@@ -63,12 +63,16 @@ func (n ShipmentResourceName) MarshalString() (string, error) {
 }
 
 func (n *ShipmentResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"shippers/{shipper}/shipments/{shipment}",
 		&n.Shipper,
 		&n.Shipment,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 func (n ShipmentResourceName) ShipperResourceName() ShipperResourceName {

--- a/proto/gen/einride/example/freight/v1/shipper_aip.go
+++ b/proto/gen/einride/example/freight/v1/shipper_aip.go
@@ -46,9 +46,13 @@ func (n ShipperResourceName) MarshalString() (string, error) {
 }
 
 func (n *ShipperResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"shippers/{shipper}",
 		&n.Shipper,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }

--- a/proto/gen/einride/example/freight/v1/site_aip.go
+++ b/proto/gen/einride/example/freight/v1/site_aip.go
@@ -63,12 +63,16 @@ func (n SiteResourceName) MarshalString() (string, error) {
 }
 
 func (n *SiteResourceName) UnmarshalString(name string) error {
-	return resourcename.Sscan(
+	err := resourcename.Sscan(
 		name,
 		"shippers/{shipper}/sites/{site}",
 		&n.Shipper,
 		&n.Site,
 	)
+	if err != nil {
+		return err
+	}
+	return n.Validate()
 }
 
 func (n SiteResourceName) ShipperResourceName() ShipperResourceName {


### PR DESCRIPTION
We are calling `Validate()` on marshalling but not on unmarshalling a resource name. This PR fixes that.