### PR TITLE
fix: bump golang.org/x/tools/cmd/stringer to 0.20.0

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -82,7 +82,7 @@ func GitVerifyNoDiff(ctx context.Context) error {
 
 func Stringer(ctx context.Context) error {
 	sg.Logger(ctx).Println("building...")
-	_, err := sgtool.GoInstall(ctx, "golang.org/x/tools/cmd/stringer", "v0.11.0")
+	_, err := sgtool.GoInstall(ctx, "golang.org/x/tools/cmd/stringer", "v0.20.0")
 	return err
 }
 


### PR DESCRIPTION
Panics in latest Go
