### PR TITLE
chore(sage): bump to v0.306.0

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -2,4 +2,4 @@ module sage
 
 go 1.19
 
-require go.einride.tech/sage v0.293.0
+require go.einride.tech/sage v0.306.0

--- a/.sage/go.sum
+++ b/.sage/go.sum
@@ -1,2 +1,2 @@
-go.einride.tech/sage v0.293.0 h1:y9jHXCAMx0HrIU4bKGLhc1jQl6iWRMly0f4MPOlzEYE=
-go.einride.tech/sage v0.293.0/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=
+go.einride.tech/sage v0.306.0 h1:FjnGGXqA11NJnV11zYhTq+tcMN4vrqMdBeSLnwfSAs0=
+go.einride.tech/sage v0.306.0/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=

--- a/filtering/lexer.go
+++ b/filtering/lexer.go
@@ -133,7 +133,7 @@ func (l *Lexer) nextRune() (rune, error) {
 	} else {
 		l.tokenEnd.Column++
 	}
-	l.tokenEnd.Offset += int32(n)
+	l.tokenEnd.Offset += int32(n) // #nosec G115
 	return r, nil
 }
 

--- a/filtering/macro.go
+++ b/filtering/macro.go
@@ -77,12 +77,12 @@ func (c *Cursor) Replace(newExpr *expr.Expr) {
 }
 
 func maxID(exp *expr.Expr) int64 {
-	var max int64
+	var maxFound int64
 	Walk(func(_, _ *expr.Expr) bool {
-		if exp.GetId() > max {
-			max = exp.GetId()
+		if exp.GetId() > maxFound {
+			maxFound = exp.GetId()
 		}
 		return true
 	}, exp)
-	return max
+	return maxFound
 }


### PR DESCRIPTION
Linter fixes:

* ignore G115 in filtering/lexer

  Not likely that `n` (width of a rune) is large enough to overflow an int32.

* rename variable to avoid shadowing built-in function

  Pleases the predeclared linter.