### PR TITLE
docs: improve usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,26 @@
 Go SDK for implementing [Google API Improvement Proposals](https://aip.dev/)
 (AIP).
 
-## Example library usage
+## Generate AIP support code from proto
+
+```bash
+go install go.einride.tech/aip/cmd/protoc-gen-go-aip
+```
+
+Add to `buf.gen.yaml`:
+
+```yaml
+version: v2
+plugins:
+  - local: protoc-gen-go-aip
+    out: gen
+    opt:
+      - paths=source_relative
+```
+
+Run `buf build` to generate e.g. `your_service_aip.go`.
+
+## Library usage examples
 
 ```bash
 go get -u go.einride.tech/aip

--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@
 Go SDK for implementing [Google API Improvement Proposals](https://aip.dev/)
 (AIP).
 
-## Installing
+## Example library usage
 
 ```bash
-$ go get -u go.einride.tech/aip
+go get -u go.einride.tech/aip
 ```
-
-## Examples
 
 ### [AIP-132](https://google.aip.dev/132) (Standard method: List)
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 Go SDK for implementing [Google API Improvement Proposals](https://aip.dev/)
 (AIP).
 
-## Documentation
-
-See [https://aip.dev](https://aip.dev/) for the full AIP documentation.
-
 ## Installing
 
 ```bash


### PR DESCRIPTION
- **docs: remove link to AIP docs, mentioned on the line above**
- **docs: be more clear about library usage**
- **docs: add separate section on codegen from proto**
