### PR TITLE
docs: add comment

### DIFF
--- a/resourceid/systemgenerated.go
+++ b/resourceid/systemgenerated.go
@@ -15,6 +15,8 @@ func NewSystemGenerated() string {
 }
 
 // NewSystemGenerated returns a new system-generated resource ID encoded as base32 lowercase.
+// Note that this function does not necessarily create valid user-settable IDs in compliance
+// with AIP-122.
 func NewSystemGeneratedBase32() string {
 	id := uuid.New()
 	return base32Encoding.EncodeToString(id[:])


### PR DESCRIPTION
## Why this change?

When setting up AIP tests, I provided
`IDGenerator: resourceid.NewSystemGeneratedBase32`, which gave me flaky tests
that sometimes returned "invalid resource name".

The reason for that was `NewSystemGeneratedBase32` does not always pass the
regexp specified in AIP-122 (`^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`) for
user-settable IDs.

## What was changed?

I just added a comment about this.
