### PR TITLE
fix(resourceid): allow user-settable IDs to have length one

### DIFF
--- a/resourceid/usersettable.go
+++ b/resourceid/usersettable.go
@@ -19,8 +19,8 @@ import (
 //
 // See also: https://google.aip.dev/133#user-specified-ids
 func ValidateUserSettable(id string) error {
-	if len(id) < 4 || 63 < len(id) {
-		return fmt.Errorf("user-settable ID must be between 4 and 63 characters")
+	if len(id) < 1 || 63 < len(id) {
+		return fmt.Errorf("user-settable ID must be between 1 and 63 characters")
 	}
 	if !unicode.IsLetter(rune(id[0])) {
 		return fmt.Errorf("user-settable ID must begin with a letter")

--- a/resourceid/usersettable_test.go
+++ b/resourceid/usersettable_test.go
@@ -1,6 +1,7 @@
 package resourceid
 
 import (
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -14,7 +15,8 @@ func TestValidateUserSettable(t *testing.T) {
 	}{
 		{id: "abcd"},
 		{id: "abcd-efgh-1234"},
-		{id: "abc", errorContains: "must be between 4 and 63 characters"},
+		{id: "", errorContains: "must be between 1 and 63 characters"},
+		{id: strings.Repeat("a", 64), errorContains: "must be between 1 and 63 characters"},
 		{id: "-abc", errorContains: "must begin with a letter"},
 		{id: "abc-", errorContains: "must end with a letter or number"},
 		{id: "123-abc", errorContains: "must begin with a letter"},


### PR DESCRIPTION
In the AIP documentation, it is never mentioned that the user-settable ID must be at least four characters.

This commit changes the validation to allow user-settable id with only one character.

Relevant AIP docs:
* [AIP-122](https://google.aip.dev/122#resource-id-segments)
* [AIP-133](https://google.aip.dev/133#user-specified-ids)

A similar fix was done in [protoc-gen-go-aip-test](https://github.com/einride/protoc-gen-go-aip-test/pull/280).