### PR TITLE
feat(protoc-gen-go-aip): support text interfaces from encoding pkg

### DIFF
--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
@@ -8,6 +8,7 @@
 package multipattern
 
 import (
+	encoding "encoding"
 	fmt "fmt"
 	resourcename "go.einride.tech/aip/resourcename"
 	strings "strings"
@@ -15,6 +16,8 @@ import (
 
 type BookMultiPatternResourceName interface {
 	fmt.Stringer
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
 	MarshalString() (string, error)
 	ContainsWildcard() bool
 }
@@ -81,6 +84,14 @@ func (n ShelvesBookResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n ShelvesBookResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *ShelvesBookResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -92,6 +103,11 @@ func (n *ShelvesBookResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *ShelvesBookResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n ShelvesBookResourceName) Type() string {
@@ -144,6 +160,14 @@ func (n PublishersBookResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n PublishersBookResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *PublishersBookResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -157,12 +181,19 @@ func (n *PublishersBookResourceName) UnmarshalString(name string) error {
 	return n.Validate()
 }
 
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *PublishersBookResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
+}
+
 func (n PublishersBookResourceName) Type() string {
 	return "test1.testdata/Book"
 }
 
 type ShelfMultiPatternResourceName interface {
 	fmt.Stringer
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
 	MarshalString() (string, error)
 	ContainsWildcard() bool
 }
@@ -215,6 +246,14 @@ func (n ShelfResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n ShelfResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *ShelfResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -225,6 +264,11 @@ func (n *ShelfResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *ShelfResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n ShelfResourceName) Type() string {
@@ -271,6 +315,14 @@ func (n LibrariesShelfResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n LibrariesShelfResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *LibrariesShelfResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -282,6 +334,11 @@ func (n *LibrariesShelfResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *LibrariesShelfResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n LibrariesShelfResourceName) Type() string {
@@ -328,6 +385,14 @@ func (n RoomsShelfResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n RoomsShelfResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *RoomsShelfResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -339,6 +404,11 @@ func (n *RoomsShelfResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *RoomsShelfResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n RoomsShelfResourceName) Type() string {

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
@@ -8,6 +8,7 @@
 package originallysinglepattern
 
 import (
+	encoding "encoding"
 	fmt "fmt"
 	resourcename "go.einride.tech/aip/resourcename"
 	strings "strings"
@@ -15,6 +16,8 @@ import (
 
 type BookMultiPatternResourceName interface {
 	fmt.Stringer
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
 	MarshalString() (string, error)
 	ContainsWildcard() bool
 }
@@ -81,6 +84,14 @@ func (n BookResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n BookResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *BookResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -92,6 +103,11 @@ func (n *BookResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *BookResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n BookResourceName) Type() string {
@@ -153,6 +169,14 @@ func (n ShelvesBookResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n ShelvesBookResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *ShelvesBookResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -164,6 +188,11 @@ func (n *ShelvesBookResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *ShelvesBookResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n ShelvesBookResourceName) Type() string {
@@ -216,6 +245,14 @@ func (n PublishersBookResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n PublishersBookResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *PublishersBookResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -229,12 +266,19 @@ func (n *PublishersBookResourceName) UnmarshalString(name string) error {
 	return n.Validate()
 }
 
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *PublishersBookResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
+}
+
 func (n PublishersBookResourceName) Type() string {
 	return "test1.testdata/Book"
 }
 
 type ShelfMultiPatternResourceName interface {
 	fmt.Stringer
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
 	MarshalString() (string, error)
 	ContainsWildcard() bool
 }
@@ -287,6 +331,14 @@ func (n ShelfResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n ShelfResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *ShelfResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -297,6 +349,11 @@ func (n *ShelfResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *ShelfResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n ShelfResourceName) Type() string {
@@ -343,6 +400,14 @@ func (n LibrariesShelfResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n LibrariesShelfResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *LibrariesShelfResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -354,6 +419,11 @@ func (n *LibrariesShelfResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *LibrariesShelfResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n LibrariesShelfResourceName) Type() string {
@@ -400,6 +470,14 @@ func (n RoomsShelfResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n RoomsShelfResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *RoomsShelfResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -411,6 +489,11 @@ func (n *RoomsShelfResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *RoomsShelfResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n RoomsShelfResourceName) Type() string {

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/testdata_aip.go
@@ -45,6 +45,14 @@ func (n ShelfResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n ShelfResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *ShelfResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -55,6 +63,11 @@ func (n *ShelfResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *ShelfResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n ShelfResourceName) Type() string {
@@ -110,6 +123,14 @@ func (n BookResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n BookResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *BookResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -121,6 +142,11 @@ func (n *BookResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *BookResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n BookResourceName) Type() string {

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/toplevelsingleton/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/toplevelsingleton/testdata_aip.go
@@ -35,6 +35,14 @@ func (n ConfigResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n ConfigResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *ConfigResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -44,6 +52,11 @@ func (n *ConfigResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *ConfigResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n ConfigResourceName) Type() string {

--- a/proto/gen/einride/example/freight/v1/shipment_aip.go
+++ b/proto/gen/einride/example/freight/v1/shipment_aip.go
@@ -62,6 +62,14 @@ func (n ShipmentResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n ShipmentResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *ShipmentResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -73,6 +81,11 @@ func (n *ShipmentResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *ShipmentResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n ShipmentResourceName) Type() string {

--- a/proto/gen/einride/example/freight/v1/shipper_aip.go
+++ b/proto/gen/einride/example/freight/v1/shipper_aip.go
@@ -45,6 +45,14 @@ func (n ShipperResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n ShipperResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *ShipperResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -55,6 +63,11 @@ func (n *ShipperResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *ShipperResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n ShipperResourceName) Type() string {

--- a/proto/gen/einride/example/freight/v1/site_aip.go
+++ b/proto/gen/einride/example/freight/v1/site_aip.go
@@ -62,6 +62,14 @@ func (n SiteResourceName) MarshalString() (string, error) {
 	return n.String(), nil
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+func (n SiteResourceName) MarshalText() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return []byte(n.String()), nil
+}
+
 func (n *SiteResourceName) UnmarshalString(name string) error {
 	err := resourcename.Sscan(
 		name,
@@ -73,6 +81,11 @@ func (n *SiteResourceName) UnmarshalString(name string) error {
 		return err
 	}
 	return n.Validate()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (n *SiteResourceName) UnmarshalText(text []byte) error {
+	return n.UnmarshalString(string(text))
 }
 
 func (n SiteResourceName) Type() string {


### PR DESCRIPTION
Namely the `encoding.TextMarshaler` and `encoding.TextUnmarshaler` interfaces. Letting the resourcename struct implement these allows them to be more versatile, e.g. allowing them to be used in config structs in cloudrunner-go and other such places.

I have manually tested that the newly generated code can be used as config in cloudrunner-go.