### PR TITLE
fix(protoc-gen-go-aip): multipattern should not implement UnmarshalText

### DIFF
--- a/cmd/protoc-gen-go-aip/internal/genaip/resourcename.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/resourcename.go
@@ -393,12 +393,10 @@ func (r resourceNameCodeGenerator) generateTypeMethod(
 func (r resourceNameCodeGenerator) generateMultiPatternInterface(g *protogen.GeneratedFile) error {
 	fmtStringer := fmtPackage.Ident("Stringer")
 	textMarshaler := encodingPackage.Ident("TextMarshaler")
-	textUnmarshaler := encodingPackage.Ident("TextUnmarshaler")
 	g.P()
 	g.P("type ", r.MultiPatternInterfaceName(), " interface {")
 	g.P(fmtStringer)
 	g.P(textMarshaler)
-	g.P(textUnmarshaler)
 	g.P("MarshalString() (string, error)")
 	g.P("ContainsWildcard() bool")
 	g.P("}")

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
@@ -17,7 +17,6 @@ import (
 type BookMultiPatternResourceName interface {
 	fmt.Stringer
 	encoding.TextMarshaler
-	encoding.TextUnmarshaler
 	MarshalString() (string, error)
 	ContainsWildcard() bool
 }
@@ -193,7 +192,6 @@ func (n PublishersBookResourceName) Type() string {
 type ShelfMultiPatternResourceName interface {
 	fmt.Stringer
 	encoding.TextMarshaler
-	encoding.TextUnmarshaler
 	MarshalString() (string, error)
 	ContainsWildcard() bool
 }

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
@@ -17,7 +17,6 @@ import (
 type BookMultiPatternResourceName interface {
 	fmt.Stringer
 	encoding.TextMarshaler
-	encoding.TextUnmarshaler
 	MarshalString() (string, error)
 	ContainsWildcard() bool
 }
@@ -278,7 +277,6 @@ func (n PublishersBookResourceName) Type() string {
 type ShelfMultiPatternResourceName interface {
 	fmt.Stringer
 	encoding.TextMarshaler
-	encoding.TextUnmarshaler
 	MarshalString() (string, error)
 	ContainsWildcard() bool
 }


### PR DESCRIPTION
This is due to it using a pointer receiver which is incompataible.