### PR TITLE
fix: remove erroneous section character in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ go get -u go.einride.tech/aip
   ) (*library.ListShelvesResponse, error) {
       // Handle request constraints.
       const (
-  §           maxPageSize     = 1000
+          maxPageSize     = 1000
           defaultPageSize = 100
       )
       switch {


### PR DESCRIPTION
This was probably intended to be a tab character.
