### PR TITLE
fix(filtering): correctly unescape strings

### DIFF
--- a/filtering/lexer.go
+++ b/filtering/lexer.go
@@ -44,6 +44,8 @@ func (l *Lexer) Lex() (Token, error) {
 		return l.emit(TokenType(l.tokenValue()))
 	// String?
 	case '\'', '"':
+		quote := r
+		escaped := false
 		for {
 			r2, err := l.nextRune()
 			if err != nil {
@@ -52,9 +54,14 @@ func (l *Lexer) Lex() (Token, error) {
 				}
 				return Token{}, err
 			}
-			if r == r2 {
+			if r2 == '\\' && !escaped {
+				escaped = true
+				continue
+			}
+			if r2 == quote && !escaped {
 				return l.emit(TokenTypeString)
 			}
+			escaped = false
 		}
 	// Number?
 	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':

--- a/filtering/parser.go
+++ b/filtering/parser.go
@@ -327,17 +327,29 @@ func (p *Parser) ParseMember() (_ *expr.Expr, err error) {
 	}
 	if !p.sniffTokens(TokenTypeDot) {
 		if valueToken.Type == TokenTypeString {
-			return parsedString(p.nextID(valueToken.Position), valueToken.Unquote()), nil
+			unquoted, err := valueToken.Unquote()
+			if err != nil {
+				return nil, err
+			}
+			return parsedString(p.nextID(valueToken.Position), unquoted), nil
 		}
 		return parsedText(p.nextID(valueToken.Position), valueToken.Value), nil
 	}
-	value := parsedText(p.nextID(valueToken.Position), valueToken.Unquote())
+	unquoted, err := valueToken.Unquote()
+	if err != nil {
+		return nil, err
+	}
+	value := parsedText(p.nextID(valueToken.Position), unquoted)
 	_ = p.eatTokens(TokenTypeDot)
 	firstFieldToken, err := p.parseToken(TokenType.IsField)
 	if err != nil {
 		return nil, err
 	}
-	member := parsedMember(p.nextID(start), value, firstFieldToken.Unquote())
+	unquoted, err = firstFieldToken.Unquote()
+	if err != nil {
+		return nil, err
+	}
+	member := parsedMember(p.nextID(start), value, unquoted)
 	for {
 		if err := p.eatTokens(TokenTypeDot); err != nil {
 			break
@@ -346,7 +358,11 @@ func (p *Parser) ParseMember() (_ *expr.Expr, err error) {
 		if err != nil {
 			return nil, err
 		}
-		member = parsedMember(p.nextID(start), member, fieldToken.Unquote())
+		unquoted, err := fieldToken.Unquote()
+		if err != nil {
+			return nil, err
+		}
+		member = parsedMember(p.nextID(start), member, unquoted)
 	}
 	return member, nil
 }
@@ -376,7 +392,11 @@ func (p *Parser) ParseFunction() (_ *expr.Expr, err error) {
 		if err != nil {
 			return nil, err
 		}
-		_, _ = name.WriteString(nameToken.Unquote())
+		unquoted, err := nameToken.Unquote()
+		if err != nil {
+			return nil, err
+		}
+		_, _ = name.WriteString(unquoted)
 		if err := p.eatTokens(TokenTypeDot); err != nil {
 			break
 		}

--- a/filtering/parser_test.go
+++ b/filtering/parser_test.go
@@ -85,9 +85,54 @@ func TestParser(t *testing.T) {
 			expected: Equals(Text("package"), Member(Text("com"), "google")),
 		},
 
+		// Simple string unescaping tests.
 		{
 			filter:   `msg != 'hello'`,
-			expected: NotEquals(Text("msg"), String("hello")),
+			expected: NotEquals(Text("msg"), String(`hello`)),
+		},
+		{
+			filter:   `msg != "hello"`,
+			expected: NotEquals(Text("msg"), String(`hello`)),
+		},
+		{
+			filter:   `msg != ""`,
+			expected: NotEquals(Text("msg"), String(``)),
+		},
+		{
+			filter:   `msg != "\\\""`,
+			expected: NotEquals(Text("msg"), String(`\"`)),
+		},
+		{
+			filter:   `msg != "\\"`,
+			expected: NotEquals(Text("msg"), String(`\`)),
+		},
+		{
+			filter:   `msg != "\303\277"`,
+			expected: NotEquals(Text("msg"), String(`Ã¿`)),
+		},
+		{
+			filter:   `msg != "\377"`,
+			expected: NotEquals(Text("msg"), String(`ÿ`)),
+		},
+		{
+			filter:   `msg != "\u263A\u263A"`,
+			expected: NotEquals(Text("msg"), String(`☺☺`)),
+		},
+		{
+			filter:   `msg != "\a\b\f\n\r\t\v\'\"\\\? Legal escapes"`,
+			expected: NotEquals(Text("msg"), String("\a\b\f\n\r\t\v'\"\\? Legal escapes")),
+		},
+		{
+			filter:   `msg != "[ 'hello' ]"`,
+			expected: NotEquals(Text("msg"), String(`[ 'hello' ]`)),
+		},
+		{
+			filter:   `msg != "[ \'hello\' ]"`,
+			expected: NotEquals(Text("msg"), String(`[ 'hello' ]`)),
+		},
+		{
+			filter:   `msg != "[ \"hello\" ]"`,
+			expected: NotEquals(Text("msg"), String(`[ "hello" ]`)),
 		},
 
 		{
@@ -188,7 +233,7 @@ func TestParser(t *testing.T) {
 
 		{
 			filter: `
-				start_time > timestamp("2006-01-02T15:04:05+07:00") AND 
+				start_time > timestamp("2006-01-02T15:04:05+07:00") AND
 				(driver = "driver1" OR start_driver = "driver1" OR end_driver = "driver1")
 			`,
 			expected: And(

--- a/filtering/token.go
+++ b/filtering/token.go
@@ -10,12 +10,9 @@ type Token struct {
 	Value string
 }
 
-func (t Token) Unquote() string {
+func (t Token) Unquote() (string, error) {
 	if t.Type == TokenTypeString {
-		if len(t.Value) <= 2 {
-			return ""
-		}
-		return t.Value[1 : len(t.Value)-1]
+		return unescape(t.Value)
 	}
-	return t.Value
+	return t.Value, nil
 }

--- a/filtering/unescape.go
+++ b/filtering/unescape.go
@@ -1,0 +1,192 @@
+package filtering
+
+import (
+	"errors"
+	"strings"
+	"unicode/utf8"
+)
+
+// The following code is adapted from
+// https://github.com/google/cel-go/blob/f6d3c92171c2c8732a8d0a4b24d6729df4261520/parser/unescape.go#L1-L237.
+
+// Unescape takes a quoted string, unquotes, and unescapes it.
+//
+// This function performs escaping compatible with GoogleSQL.
+func unescape(value string) (string, error) {
+	// All strings normalize newlines to the \n representation.
+	value = newlineNormalizer.Replace(value)
+	n := len(value)
+
+	// Nothing to unescape / decode.
+	if n < 2 {
+		return value, errors.New("unable to unescape string")
+	}
+
+	// Quoted string of some form, must have same first and last char.
+	if value[0] != value[n-1] || (value[0] != '"' && value[0] != '\'') {
+		return value, errors.New("unable to unescape string")
+	}
+
+	value = value[1 : n-1]
+	// If there is nothing to escape, then return.
+	if !strings.ContainsRune(value, '\\') {
+		return value, nil
+	}
+
+	// Otherwise the string contains escape characters.
+	// The following logic is adapted from `strconv/quote.go`
+	var runeTmp [utf8.UTFMax]byte
+	buf := make([]byte, 0, 3*n/2)
+	for len(value) > 0 {
+		c, encode, rest, err := unescapeChar(value, false)
+		if err != nil {
+			return "", err
+		}
+		value = rest
+		if c < utf8.RuneSelf || !encode {
+			buf = append(buf, byte(c))
+		} else {
+			n := utf8.EncodeRune(runeTmp[:], c)
+			buf = append(buf, runeTmp[:n]...)
+		}
+	}
+	return string(buf), nil
+}
+
+// unescapeChar takes a string input and returns the following info:
+//
+//	value - the escaped unicode rune at the front of the string.
+//	encode - the value should be unicode-encoded
+//	tail - the remainder of the input string.
+//	err - error value, if the character could not be unescaped.
+//
+// When encode is true the return value may still fit within a single byte,
+// but unicode encoding is attempted which is more expensive than when the
+// value is known to self-represent as a single byte.
+//
+// If isBytes is set, unescape as a bytes literal so octal and hex escapes
+// represent byte values, not unicode code points.
+func unescapeChar(s string, isBytes bool) (value rune, encode bool, tail string, err error) {
+	// 1. Character is not an escape sequence.
+	switch c := s[0]; {
+	case c >= utf8.RuneSelf:
+		r, size := utf8.DecodeRuneInString(s)
+		return r, true, s[size:], nil
+	case c != '\\':
+		return rune(s[0]), false, s[1:], nil
+	}
+
+	// 2. Last character is the start of an escape sequence.
+	if len(s) <= 1 {
+		return value, encode, tail, errors.New("unable to unescape string, found '\\' as last character")
+	}
+
+	c := s[1]
+	s = s[2:]
+	// 3. Common escape sequences shared with Google SQL
+	switch c {
+	case 'a':
+		value = '\a'
+	case 'b':
+		value = '\b'
+	case 'f':
+		value = '\f'
+	case 'n':
+		value = '\n'
+	case 'r':
+		value = '\r'
+	case 't':
+		value = '\t'
+	case 'v':
+		value = '\v'
+	case '\\':
+		value = '\\'
+	case '\'':
+		value = '\''
+	case '"':
+		value = '"'
+	case '`':
+		value = '`'
+	case '?':
+		value = '?'
+
+	// 4. Unicode escape sequences, reproduced from `strconv/quote.go`
+	case 'x', 'X', 'u', 'U':
+		n := 0
+		encode = true
+		switch c {
+		case 'x', 'X':
+			n = 2
+			encode = !isBytes
+		case 'u':
+			n = 4
+			if isBytes {
+				return value, encode, tail, errors.New("unable to unescape string")
+			}
+		case 'U':
+			n = 8
+			if isBytes {
+				return value, encode, tail, errors.New("unable to unescape string")
+			}
+		}
+		var v rune
+		if len(s) < n {
+			return value, encode, tail, errors.New("unable to unescape string")
+		}
+		for j := 0; j < n; j++ {
+			x, ok := unhex(s[j])
+			if !ok {
+				return value, encode, tail, errors.New("unable to unescape string")
+			}
+			v = v<<4 | x
+		}
+		s = s[n:]
+		if !isBytes && !utf8.ValidRune(v) {
+			return value, encode, tail, errors.New("invalid unicode code point")
+		}
+		value = v
+
+	// 5. Octal escape sequences, must be three digits \[0-3][0-7][0-7]
+	case '0', '1', '2', '3':
+		if len(s) < 2 {
+			return value, encode, tail, errors.New("unable to unescape octal sequence in string")
+		}
+		v := rune(c - '0')
+		for j := 0; j < 2; j++ {
+			x := s[j]
+			if x < '0' || x > '7' {
+				return value, encode, tail, errors.New("unable to unescape octal sequence in string")
+			}
+			v = v*8 + rune(x-'0')
+		}
+		if !isBytes && !utf8.ValidRune(v) {
+			return value, encode, tail, errors.New("invalid unicode code point")
+		}
+		value = v
+		s = s[2:]
+		encode = !isBytes
+
+		// Unknown escape sequence.
+	default:
+		err = errors.New("unable to unescape string")
+	}
+
+	tail = s
+	return value, encode, tail, err
+}
+
+func unhex(b byte) (rune, bool) {
+	c := rune(b)
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0', true
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10, true
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
+}
+
+//nolint:gochecknoglobals
+var newlineNormalizer = strings.NewReplacer("\r\n", "\n", "\r", "\n")

--- a/filtering/unescape_test.go
+++ b/filtering/unescape_test.go
@@ -1,0 +1,55 @@
+package filtering
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The following code is adapted from
+// https://github.com/google/cel-go/blob/f6d3c92171c2c8732a8d0a4b24d6729df4261520/parser/unescape.go#L1-L237.
+
+func TestUnescape(t *testing.T) {
+	tests := []struct {
+		in  string
+		out interface{}
+	}{
+		// Simple string unescaping tests.
+		{in: `'hello'`, out: `hello`},
+		{in: `""`, out: ``},
+		{in: `"\\\""`, out: `\"`},
+		{in: `"\\"`, out: `\`},
+		{in: `"\303\277"`, out: `Ã¿`},
+		{in: `"\377"`, out: `ÿ`},
+		{in: `"\u263A\u263A"`, out: `☺☺`},
+		{in: `"\a\b\f\n\r\t\v\'\"\\\? Legal escapes"`, out: "\a\b\f\n\r\t\v'\"\\? Legal escapes"},
+		// Escaping errors.
+		{in: `"\a\b\f\n\r\t\v\'\"\\\? Illegal escape \>"`, out: errors.New("unable to unescape string")},
+		{in: `"\u00f"`, out: errors.New("unable to unescape string")},
+		{in: `"\u00fÿ"`, out: errors.New("unable to unescape string")},
+		{in: `"\26"`, out: errors.New("unable to unescape octal sequence")},
+		{in: `"\268"`, out: errors.New("unable to unescape octal sequence")},
+		{in: `"\267\"`, out: errors.New(`found '\' as last character`)},
+		{in: `'`, out: errors.New("unable to unescape string")},
+		{in: `*hello*`, out: errors.New("unable to unescape string")},
+	}
+
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := unescape(tc.in)
+			if err != nil {
+				expect, isErr := tc.out.(error)
+				if isErr {
+					if !strings.Contains(err.Error(), expect.Error()) {
+						t.Errorf("unescape(%s) errored with %v, wanted %v", tc.in, err, expect)
+					}
+				} else {
+					t.Fatalf("unescape(%s) failed: %v", tc.in, err)
+				}
+			} else if got != tc.out {
+				t.Errorf("unescape(%s) got %v, wanted %v", tc.in, got, tc.out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `filtering` package now correctly handles (un)escaping of strings. I used https://github.com/google/cel-spec/blob/master/doc/langdef.md#string-and-bytes-values and https://github.com/google/cel-go/blob/master/parser/unescape.go to solve this.