### PR TITLE
feat(usersettable): allow id to have the form of an uuid

### DIFF
--- a/resourceid/usersettable.go
+++ b/resourceid/usersettable.go
@@ -3,8 +3,6 @@ package resourceid
 import (
 	"fmt"
 	"unicode"
-
-	"github.com/google/uuid"
 )
 
 // ValidateUserSettable validates a user-settable resource ID.
@@ -27,9 +25,6 @@ func ValidateUserSettable(id string) error {
 	}
 	if id[len(id)-1] == '-' {
 		return fmt.Errorf("user-settable ID must end with a letter or number")
-	}
-	if _, err := uuid.Parse(id); err == nil {
-		return fmt.Errorf("user-settable ID must not be a valid UUIDv4")
 	}
 	for position, character := range id {
 		switch character {

--- a/resourceid/usersettable_test.go
+++ b/resourceid/usersettable_test.go
@@ -20,7 +20,7 @@ func TestValidateUserSettable(t *testing.T) {
 		{id: "-abc", errorContains: "must begin with a letter"},
 		{id: "abc-", errorContains: "must end with a letter or number"},
 		{id: "123-abc", errorContains: "must begin with a letter"},
-		{id: "daf1cb3e-f33b-43f1-81cc-e65fda51efa5", errorContains: "must not be a valid UUIDv4"},
+		{id: "daf1cb3e-f33b-43f1-81cc-e65fda51efa5"},
 		{id: "abcd/efgh", errorContains: "must only contain lowercase, numbers and hyphens"},
 	} {
 		tt := tt


### PR DESCRIPTION
Since this [PR](https://github.com/aip-dev/google.aip.dev/pull/1491),
usersettable id can now take the form of an UUID, this commit reflects
that.
