### PR TITLE
chore: add dependabot cooldown settings to mitigate ongoing supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
 
     cooldown:
       default-days: 7
+      exclude:
+        - github.com/einride/*
+        - github.com/einride-autonomous/*
+        - github.com/einride-labs/*
   - package-ecosystem: gomod
     directories: [".", ".sage"]
     schedule:
@@ -20,3 +24,7 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+      exclude:
+        - github.com/einride/*
+        - github.com/einride-autonomous/*
+        - github.com/einride-labs/*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
 
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
   - package-ecosystem: gomod
     directories: [".", ".sage"]
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: monthly
 
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: gomod
     directories: [".", ".sage"]
     schedule:
@@ -13,3 +18,8 @@ updates:
     groups:
       go-dependencies:
         patterns: ["*"]
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
## Summary

Adds `cooldown` configuration to every package ecosystem in `.github/dependabot.yml` to reduce exposure to ongoing supply chain attacks by limiting how quickly compromised or malicious package versions can be automatically adopted.

```yaml
cooldown:
  default-days: 7
  semver-major-days: 30
  semver-minor-days: 7
  semver-patch-days: 3
  exclude:
    - github.com/einride/*
    - github.com/einride-autonomous/*
    - github.com/einride-labs/*
```

Security updates are automatically exempt from this cooldown.
