### PR TITLE
chore: Bump linter version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Sage
         uses: einride/sage/actions/setup@master
         with:
-          go-version-file: go.mod
+          go-version-file: .sage/go.mod
 
       - name: Make
         run: make

--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -1,7 +1,5 @@
 module sage
 
-go 1.22
+go 1.25.7
 
-toolchain go1.24.1
-
-require go.einride.tech/sage v0.370.0
+require go.einride.tech/sage v0.409.0

--- a/.sage/go.sum
+++ b/.sage/go.sum
@@ -1,2 +1,2 @@
-go.einride.tech/sage v0.370.0 h1:BmQbf/Pp2GTwCr6MnRHZFADw1vokSfQ6Je21MJP0FKM=
-go.einride.tech/sage v0.370.0/go.mod h1:sy9YuK//XVwEZ2wD3f19xVSKEtN8CYtgtBZGpzC3p80=
+go.einride.tech/sage v0.409.0 h1:o4hqjRPH1EO8XZsUcfA8E9p3HWlu3X19wPf9p8hY8YM=
+go.einride.tech/sage v0.409.0/go.mod h1:k/GWZv8EP64DxdCSZt9GIYMgOCxntdfE6FTRTIzQVdE=

--- a/.sage/main.go
+++ b/.sage/main.go
@@ -8,7 +8,7 @@ import (
 	"go.einride.tech/sage/tools/sgconvco"
 	"go.einride.tech/sage/tools/sggit"
 	"go.einride.tech/sage/tools/sggo"
-	"go.einride.tech/sage/tools/sggolangcilint"
+	"go.einride.tech/sage/tools/sggolangcilintv2"
 	"go.einride.tech/sage/tools/sggolines"
 	"go.einride.tech/sage/tools/sggosemanticrelease"
 	"go.einride.tech/sage/tools/sgmdformat"
@@ -53,12 +53,12 @@ func FormatMarkdown(ctx context.Context) error {
 
 func GoLint(ctx context.Context) error {
 	sg.Logger(ctx).Println("linting Go files...")
-	return sggolangcilint.Run(ctx)
+	return sggolangcilintv2.Run(ctx, sggolangcilintv2.Config{})
 }
 
 func GoLintFix(ctx context.Context) error {
 	sg.Logger(ctx).Println("fixing Go files...")
-	return sggolangcilint.Fix(ctx)
+	return sggolangcilintv2.Fix(ctx, sggolangcilintv2.Config{})
 }
 
 func GoLines(ctx context.Context) error {

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sagefile := $(abspath $(cwd)/.sage/bin/sagefile)
 go := $(shell command -v go 2>/dev/null)
 export GOWORK ?= off
 ifndef go
-SAGE_GO_VERSION ?= 1.23.4
+SAGE_GO_VERSION ?= 1.25.7
 export GOROOT := $(abspath $(cwd)/.sage/tools/go/$(SAGE_GO_VERSION)/go)
 export PATH := $(PATH):$(GOROOT)/bin
 go := $(GOROOT)/bin/go

--- a/cmd/protoc-gen-go-aip/internal/genaip/resourcename.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/resourcename.go
@@ -426,7 +426,8 @@ func (r *resourceNameCodeGenerator) SinglePatternStructName() string {
 }
 
 func (r *resourceNameCodeGenerator) StructName(pattern string) string {
-	if r.resource.GetHistory() == annotations.ResourceDescriptor_FUTURE_MULTI_PATTERN || len(r.resource.GetPattern()) > 1 {
+	if r.resource.GetHistory() == annotations.ResourceDescriptor_FUTURE_MULTI_PATTERN ||
+		len(r.resource.GetPattern()) > 1 {
 		return r.MultiPatternStructName(pattern)
 	}
 	if r.resource.GetPattern()[0] == pattern {

--- a/cmd/protoc-gen-go-aip/main.go
+++ b/cmd/protoc-gen-go-aip/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"go.einride.tech/aip/cmd/protoc-gen-go-aip/internal/genaip"
 	"google.golang.org/protobuf/compiler/protogen"
@@ -14,7 +15,7 @@ import (
 func main() {
 	log.SetFlags(0)
 	if len(os.Args) == 2 && os.Args[1] == "--version" {
-		log.Printf("%v %v\n", filepath.Base(os.Args[0]), genaip.PluginVersion)
+		log.Printf("%v %v\n", strings.ReplaceAll(filepath.Base(os.Args[0]), "\n", ""), genaip.PluginVersion)
 		os.Exit(0)
 	}
 	var (

--- a/examples/examplelibrary/listshelves.go
+++ b/examples/examplelibrary/listshelves.go
@@ -19,11 +19,11 @@ func (s *Server) ListShelves(
 		defaultPageSize = 100
 	)
 	switch {
-	case request.PageSize < 0:
+	case request.GetPageSize() < 0:
 		return nil, status.Errorf(codes.InvalidArgument, "page size is negative")
-	case request.PageSize == 0:
+	case request.GetPageSize() == 0:
 		request.PageSize = defaultPageSize
-	case request.PageSize > maxPageSize:
+	case request.GetPageSize() > maxPageSize:
 		request.PageSize = maxPageSize
 	}
 	// Use pagination.PageToken for offset-based page tokens.

--- a/examples/examplelibrary/listshelves_test.go
+++ b/examples/examplelibrary/listshelves_test.go
@@ -24,21 +24,21 @@ func ExampleServer_ListShelves() {
 	if err != nil {
 		panic(err) // TODO: Handle errors.
 	}
-	for _, shelf := range page1.Shelves {
-		fmt.Println(shelf.Name, shelf.Theme)
+	for _, shelf := range page1.GetShelves() {
+		fmt.Println(shelf.GetName(), shelf.GetTheme())
 	}
-	fmt.Println("page1.NextPageToken non-empty:", page1.NextPageToken != "")
+	fmt.Println("page1.NextPageToken non-empty:", page1.GetNextPageToken() != "")
 	page2, err := server.ListShelves(ctx, &library.ListShelvesRequest{
 		PageSize:  2,
-		PageToken: page1.NextPageToken,
+		PageToken: page1.GetNextPageToken(),
 	})
 	if err != nil {
 		panic(err) // TODO: Handle errors.
 	}
-	for _, shelf := range page2.Shelves {
-		fmt.Println(shelf.Name, shelf.Theme)
+	for _, shelf := range page2.GetShelves() {
+		fmt.Println(shelf.GetName(), shelf.GetTheme())
 	}
-	fmt.Println("page2.NextPageToken non-empty:", page2.NextPageToken != "")
+	fmt.Println("page2.NextPageToken non-empty:", page2.GetNextPageToken() != "")
 	// Output:
 	// shelves/0001 Sci-Fi
 	// shelves/0002 Horror

--- a/filtering/macro.go
+++ b/filtering/macro.go
@@ -12,7 +12,11 @@ type Macro func(*Cursor)
 // ApplyMacros applies the provided macros to the filter and type-checks the result against the provided declarations.
 func ApplyMacros(filter Filter, declarations *Declarations, macros ...Macro) (Filter, error) {
 	// We ignore the return value as we validate against the given declarations instead.
-	_, err := applyMacros(filter.CheckedExpr.GetExpr(), filter.CheckedExpr.GetSourceInfo(), filter.declarations, macros...)
+	_, err := applyMacros(
+		filter.CheckedExpr.GetExpr(),
+		filter.CheckedExpr.GetSourceInfo(),
+		filter.declarations,
+		macros...)
 	if err != nil {
 		return Filter{}, err
 	}

--- a/filtering/parser.go
+++ b/filtering/parser.go
@@ -250,7 +250,7 @@ func (p *Parser) ParseRestriction() (_ *expr.Expr, err error) {
 	if err != nil {
 		return nil, err
 	}
-	if !(p.sniff(TokenType.IsComparator) || p.sniff(TokenTypeWhitespace.Test, TokenType.IsComparator)) {
+	if !p.sniff(TokenType.IsComparator) && !p.sniff(TokenTypeWhitespace.Test, TokenType.IsComparator) {
 		return comp, nil
 	}
 	_ = p.eatTokens(TokenTypeWhitespace)

--- a/filtering/proto_test.go
+++ b/filtering/proto_test.go
@@ -165,25 +165,34 @@ func TestDeclareProtoMessageIdents(t *testing.T) {
 		},
 		// Deeply nested field
 		{
-			name:         "ok - deeply nested field",
-			opts:         []FilterOption{WithFilterableFields("nested_message.deep_nested.deep_string")},
-			filter:       `nested_message.deep_nested.deep_string = "deep_value"`,
-			expectedExpr: Equals(Member(Member(Text("nested_message"), "deep_nested"), "deep_string"), String("deep_value")),
-			expectError:  false,
+			name:   "ok - deeply nested field",
+			opts:   []FilterOption{WithFilterableFields("nested_message.deep_nested.deep_string")},
+			filter: `nested_message.deep_nested.deep_string = "deep_value"`,
+			expectedExpr: Equals(
+				Member(Member(Text("nested_message"), "deep_nested"), "deep_string"),
+				String("deep_value"),
+			),
+			expectError: false,
 		},
 		{
-			name:         "ok - deeply nested field, filter by parent field",
-			opts:         []FilterOption{WithFilterableFields("nested_message.deep_nested")},
-			filter:       `nested_message.deep_nested.deep_string = "deep_value"`,
-			expectedExpr: Equals(Member(Member(Text("nested_message"), "deep_nested"), "deep_string"), String("deep_value")),
-			expectError:  false,
+			name:   "ok - deeply nested field, filter by parent field",
+			opts:   []FilterOption{WithFilterableFields("nested_message.deep_nested")},
+			filter: `nested_message.deep_nested.deep_string = "deep_value"`,
+			expectedExpr: Equals(
+				Member(Member(Text("nested_message"), "deep_nested"), "deep_string"),
+				String("deep_value"),
+			),
+			expectError: false,
 		},
 		{
-			name:         "ok - deeply nested field, filter by parent parent",
-			opts:         []FilterOption{WithFilterableFields("nested_message")},
-			filter:       `nested_message.deep_nested.deep_string = "deep_value"`,
-			expectedExpr: Equals(Member(Member(Text("nested_message"), "deep_nested"), "deep_string"), String("deep_value")),
-			expectError:  false,
+			name:   "ok - deeply nested field, filter by parent parent",
+			opts:   []FilterOption{WithFilterableFields("nested_message")},
+			filter: `nested_message.deep_nested.deep_string = "deep_value"`,
+			expectedExpr: Equals(
+				Member(Member(Text("nested_message"), "deep_nested"), "deep_string"),
+				String("deep_value"),
+			),
+			expectError: false,
 		},
 		// Complex expressions
 		{

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module go.einride.tech/aip
 
-go 1.23.0
-
-toolchain go1.24.4
+go 1.25.7
 
 require (
 	github.com/google/uuid v1.6.0

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -10,7 +10,7 @@ sagefile := $(abspath $(cwd)/../.sage/bin/sagefile)
 go := $(shell command -v go 2>/dev/null)
 export GOWORK ?= off
 ifndef go
-SAGE_GO_VERSION ?= 1.23.4
+SAGE_GO_VERSION ?= 1.25.7
 export GOROOT := $(abspath $(cwd)/../.sage/tools/go/$(SAGE_GO_VERSION)/go)
 export PATH := $(PATH):$(GOROOT)/bin
 go := $(GOROOT)/bin/go

--- a/resourcename/validate.go
+++ b/resourcename/validate.go
@@ -74,7 +74,7 @@ func isSnakeCase(s string) bool {
 			if !unicode.IsLower(r) {
 				return false
 			}
-		} else if !(r == '_' || unicode.In(r, unicode.Lower, unicode.Digit)) {
+		} else if r != '_' && !unicode.In(r, unicode.Lower, unicode.Digit) {
 			return false
 		}
 	}

--- a/validation/error.go
+++ b/validation/error.go
@@ -61,7 +61,7 @@ func (e *Error) Error() string {
 			var result strings.Builder
 			_, _ = result.WriteString("field violation on multiple fields:\n")
 			for i, fieldViolation := range e.fieldViolations {
-				_, _ = result.WriteString(fmt.Sprintf(" | %s: %s", fieldViolation.GetField(), fieldViolation.GetDescription()))
+				_, _ = fmt.Fprintf(&result, " | %s: %s", fieldViolation.GetField(), fieldViolation.GetDescription())
 				if i < len(e.fieldViolations)-1 {
 					_ = result.WriteByte('\n')
 				}


### PR DESCRIPTION
Update linter to sggolangcilintv2, and Sage and Go versions, to fix linter error:

[go-lint] linting Go files...
[go-lint] ../../../../sdk/go1.26.2/src/vendor/golang.org/x/crypto/chacha20poly1305/fips140only_go1.26.go:7:9: file requires newer Go version go1.26 (application built with go1.24) (typecheck)

Also fixed some errors detected by the updated linter.
