### PR TITLE
feat: add pattern method to resource name

### DIFF
--- a/cmd/protoc-gen-go-aip/internal/genaip/resourcename.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/resourcename.go
@@ -129,6 +129,9 @@ func (r resourceNameCodeGenerator) generatePatternStruct(
 	if err := r.generateTypeMethod(g, typeName); err != nil {
 		return err
 	}
+	if err := r.generatePatternMethod(g, typeName, pattern); err != nil {
+		return err
+	}
 	var parentErr error
 	aipreflect.RangeParentResourcesInPackage(
 		r.files,
@@ -386,6 +389,19 @@ func (r resourceNameCodeGenerator) generateTypeMethod(
 	g.P()
 	g.P("func (n ", typeName, ") Type() string {")
 	g.P("return ", strconv.Quote(r.resource.GetType()))
+	g.P("}")
+	return nil
+}
+
+func (r resourceNameCodeGenerator) generatePatternMethod(
+	g *protogen.GeneratedFile,
+	typeName string,
+	pattern string,
+) error {
+	g.P()
+	g.P("// Pattern returns the resource name pattern for ", typeName, " as a string.")
+	g.P("func (n ", typeName, ") Pattern() string {")
+	g.P("return ", strconv.Quote(pattern))
 	g.P("}")
 	return nil
 }

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/pattern_test.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/pattern_test.go
@@ -33,6 +33,14 @@ func TestParseBookMultiPatternResourceName(t *testing.T) {
 			assert.Error(t, err, "no matching pattern")
 		})
 	}
+
+	t.Run("pattern method multipattern", func(t *testing.T) {
+		var shelvesRN ShelvesBookResourceName
+		assert.Equal(t, shelvesRN.Pattern(), "shelves/{shelf}/books/{book}")
+
+		var publisherRN PublishersBookResourceName
+		assert.Equal(t, publisherRN.Pattern(), "publishers/{publisher}/books/{book}")
+	})
 }
 
 func TestShelvesBookResourceName(t *testing.T) {

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/multipattern/testdata_aip.go
@@ -113,6 +113,11 @@ func (n ShelvesBookResourceName) Type() string {
 	return "test1.testdata/Book"
 }
 
+// Pattern returns the resource name pattern for ShelvesBookResourceName as a string.
+func (n ShelvesBookResourceName) Pattern() string {
+	return "shelves/{shelf}/books/{book}"
+}
+
 func (n ShelvesBookResourceName) ShelfResourceName() ShelfResourceName {
 	return ShelfResourceName{
 		Shelf: n.Shelf,
@@ -187,6 +192,11 @@ func (n *PublishersBookResourceName) UnmarshalText(text []byte) error {
 
 func (n PublishersBookResourceName) Type() string {
 	return "test1.testdata/Book"
+}
+
+// Pattern returns the resource name pattern for PublishersBookResourceName as a string.
+func (n PublishersBookResourceName) Pattern() string {
+	return "publishers/{publisher}/books/{book}"
 }
 
 type ShelfMultiPatternResourceName interface {
@@ -273,6 +283,11 @@ func (n ShelfResourceName) Type() string {
 	return "test1.testdata/Shelf"
 }
 
+// Pattern returns the resource name pattern for ShelfResourceName as a string.
+func (n ShelfResourceName) Pattern() string {
+	return "shelves/{shelf}"
+}
+
 type LibrariesShelfResourceName struct {
 	Library string
 	Shelf   string
@@ -343,6 +358,11 @@ func (n LibrariesShelfResourceName) Type() string {
 	return "test1.testdata/Shelf"
 }
 
+// Pattern returns the resource name pattern for LibrariesShelfResourceName as a string.
+func (n LibrariesShelfResourceName) Pattern() string {
+	return "libraries/{library}/shelves/{shelf}"
+}
+
 type RoomsShelfResourceName struct {
 	Room  string
 	Shelf string
@@ -411,4 +431,9 @@ func (n *RoomsShelfResourceName) UnmarshalText(text []byte) error {
 
 func (n RoomsShelfResourceName) Type() string {
 	return "test1.testdata/Shelf"
+}
+
+// Pattern returns the resource name pattern for RoomsShelfResourceName as a string.
+func (n RoomsShelfResourceName) Pattern() string {
+	return "rooms/{room}/shelves/{shelf}"
 }

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/originallysinglepattern/testdata_aip.go
@@ -113,6 +113,11 @@ func (n BookResourceName) Type() string {
 	return "test1.testdata/Book"
 }
 
+// Pattern returns the resource name pattern for BookResourceName as a string.
+func (n BookResourceName) Pattern() string {
+	return "shelves/{shelf}/books/{book}"
+}
+
 func (n BookResourceName) ShelfResourceName() ShelfResourceName {
 	return ShelfResourceName{
 		Shelf: n.Shelf,
@@ -198,6 +203,11 @@ func (n ShelvesBookResourceName) Type() string {
 	return "test1.testdata/Book"
 }
 
+// Pattern returns the resource name pattern for ShelvesBookResourceName as a string.
+func (n ShelvesBookResourceName) Pattern() string {
+	return "shelves/{shelf}/books/{book}"
+}
+
 func (n ShelvesBookResourceName) ShelfResourceName() ShelfResourceName {
 	return ShelfResourceName{
 		Shelf: n.Shelf,
@@ -272,6 +282,11 @@ func (n *PublishersBookResourceName) UnmarshalText(text []byte) error {
 
 func (n PublishersBookResourceName) Type() string {
 	return "test1.testdata/Book"
+}
+
+// Pattern returns the resource name pattern for PublishersBookResourceName as a string.
+func (n PublishersBookResourceName) Pattern() string {
+	return "publishers/{publisher}/books/{book}"
 }
 
 type ShelfMultiPatternResourceName interface {
@@ -358,6 +373,11 @@ func (n ShelfResourceName) Type() string {
 	return "test1.testdata/Shelf"
 }
 
+// Pattern returns the resource name pattern for ShelfResourceName as a string.
+func (n ShelfResourceName) Pattern() string {
+	return "shelves/{shelf}"
+}
+
 type LibrariesShelfResourceName struct {
 	Library string
 	Shelf   string
@@ -428,6 +448,11 @@ func (n LibrariesShelfResourceName) Type() string {
 	return "test1.testdata/Shelf"
 }
 
+// Pattern returns the resource name pattern for LibrariesShelfResourceName as a string.
+func (n LibrariesShelfResourceName) Pattern() string {
+	return "libraries/{library}/shelves/{shelf}"
+}
+
 type RoomsShelfResourceName struct {
 	Room  string
 	Shelf string
@@ -496,4 +521,9 @@ func (n *RoomsShelfResourceName) UnmarshalText(text []byte) error {
 
 func (n RoomsShelfResourceName) Type() string {
 	return "test1.testdata/Shelf"
+}
+
+// Pattern returns the resource name pattern for RoomsShelfResourceName as a string.
+func (n RoomsShelfResourceName) Pattern() string {
+	return "rooms/{room}/shelves/{shelf}"
 }

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/pattern_test.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/pattern_test.go
@@ -44,6 +44,11 @@ func TestBookResourceName(t *testing.T) {
 			"parse resource name 'others/other/books/book' with pattern 'shelves/{shelf}/books/{book}': segment shelves: got others",
 		)
 	})
+
+	t.Run("pattern method", func(t *testing.T) {
+		var name BookResourceName
+		assert.Equal(t, name.Pattern(), "shelves/{shelf}/books/{book}")
+	})
 }
 
 func TestShelfResourceName(t *testing.T) {

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/single/testdata_aip.go
@@ -74,6 +74,11 @@ func (n ShelfResourceName) Type() string {
 	return "test1.testdata/Shelf"
 }
 
+// Pattern returns the resource name pattern for ShelfResourceName as a string.
+func (n ShelfResourceName) Pattern() string {
+	return "shelves/{shelf}"
+}
+
 type BookResourceName struct {
 	Shelf string
 	Book  string
@@ -151,6 +156,11 @@ func (n *BookResourceName) UnmarshalText(text []byte) error {
 
 func (n BookResourceName) Type() string {
 	return "test1.testdata/Book"
+}
+
+// Pattern returns the resource name pattern for BookResourceName as a string.
+func (n BookResourceName) Pattern() string {
+	return "shelves/{shelf}/books/{book}"
 }
 
 func (n BookResourceName) ShelfResourceName() ShelfResourceName {

--- a/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/toplevelsingleton/testdata_aip.go
+++ b/cmd/protoc-gen-go-aip/internal/genaip/testdata/test/toplevelsingleton/testdata_aip.go
@@ -62,3 +62,8 @@ func (n *ConfigResourceName) UnmarshalText(text []byte) error {
 func (n ConfigResourceName) Type() string {
 	return "test1.testdata/Config"
 }
+
+// Pattern returns the resource name pattern for ConfigResourceName as a string.
+func (n ConfigResourceName) Pattern() string {
+	return "config"
+}

--- a/proto/gen/einride/example/freight/v1/shipment_aip.go
+++ b/proto/gen/einride/example/freight/v1/shipment_aip.go
@@ -92,6 +92,11 @@ func (n ShipmentResourceName) Type() string {
 	return "freight-example.einride.tech/Shipment"
 }
 
+// Pattern returns the resource name pattern for ShipmentResourceName as a string.
+func (n ShipmentResourceName) Pattern() string {
+	return "shippers/{shipper}/shipments/{shipment}"
+}
+
 func (n ShipmentResourceName) ShipperResourceName() ShipperResourceName {
 	return ShipperResourceName{
 		Shipper: n.Shipper,

--- a/proto/gen/einride/example/freight/v1/shipper_aip.go
+++ b/proto/gen/einride/example/freight/v1/shipper_aip.go
@@ -73,3 +73,8 @@ func (n *ShipperResourceName) UnmarshalText(text []byte) error {
 func (n ShipperResourceName) Type() string {
 	return "freight-example.einride.tech/Shipper"
 }
+
+// Pattern returns the resource name pattern for ShipperResourceName as a string.
+func (n ShipperResourceName) Pattern() string {
+	return "shippers/{shipper}"
+}

--- a/proto/gen/einride/example/freight/v1/site_aip.go
+++ b/proto/gen/einride/example/freight/v1/site_aip.go
@@ -92,6 +92,11 @@ func (n SiteResourceName) Type() string {
 	return "freight-example.einride.tech/Site"
 }
 
+// Pattern returns the resource name pattern for SiteResourceName as a string.
+func (n SiteResourceName) Pattern() string {
+	return "shippers/{shipper}/sites/{site}"
+}
+
 func (n SiteResourceName) ShipperResourceName() ShipperResourceName {
 	return ShipperResourceName{
 		Shipper: n.Shipper,


### PR DESCRIPTION
Exposing the pattern of the resource name through a method on the resource name. Usage for now is to have the pattern available when doing AIP filter validation on resource names.