### PR TITLE
feat(pagination): add Cursor field to PageToken for key set pagination

### DIFF
--- a/pagination/pagetoken.go
+++ b/pagination/pagetoken.go
@@ -8,6 +8,8 @@ import (
 type PageToken struct {
 	// Offset of the page.
 	Offset int64
+	// Cursor for key set pagination.
+	Cursor []any
 	// RequestChecksum is the checksum of the request that generated the page token.
 	RequestChecksum uint32
 }

--- a/pagination/pagetoken_test.go
+++ b/pagination/pagetoken_test.go
@@ -171,6 +171,33 @@ func TestParseOffsetPageToken(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Assert(t, pageToken2.Cursor == nil)
 		})
+		t.Run("token encoded before cursor field is added", func(t *testing.T) {
+			t.Parallel()
+			// Token shape from before the Cursor field was added.
+			type legacyPageToken struct {
+				Offset          int64
+				RequestChecksum uint32
+			}
+			request := &library.ListBooksRequest{
+				Parent:   "shelves/1",
+				PageSize: 10,
+			}
+			checksum, err := CalculateRequestChecksum(request)
+			assert.NilError(t, err)
+			checksum ^= pageTokenChecksumMask
+			legacy := EncodePageTokenStruct(&legacyPageToken{
+				Offset:          42,
+				RequestChecksum: checksum,
+			})
+			parsed, err := ParsePageToken(&library.ListBooksRequest{
+				Parent:    "shelves/1",
+				PageSize:  10,
+				PageToken: legacy,
+			})
+			assert.NilError(t, err)
+			assert.Equal(t, int64(42), parsed.Offset)
+			assert.Assert(t, parsed.Cursor == nil)
+		})
 	})
 	t.Run("invalid format", func(t *testing.T) {
 		t.Parallel()

--- a/pagination/pagetoken_test.go
+++ b/pagination/pagetoken_test.go
@@ -121,6 +121,57 @@ func TestParseOffsetPageToken(t *testing.T) {
 			assert.Equal(t, int64(100), pageToken3.Offset)
 		})
 	})
+	t.Run("cursor", func(t *testing.T) {
+		t.Parallel()
+		t.Run("round-trip preserves cursor", func(t *testing.T) {
+			t.Parallel()
+			request1 := &library.ListBooksRequest{
+				Parent:   "shelves/1",
+				PageSize: 10,
+			}
+			pageToken1, err := ParsePageToken(request1)
+			assert.NilError(t, err)
+			pageToken1.Cursor = []any{"abc", int64(42)}
+			request2 := &library.ListBooksRequest{
+				Parent:    "shelves/1",
+				PageSize:  10,
+				PageToken: pageToken1.String(),
+			}
+			pageToken2, err := ParsePageToken(request2)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, []any{"abc", int64(42)}, pageToken2.Cursor)
+		})
+		t.Run("Next preserves cursor", func(t *testing.T) {
+			t.Parallel()
+			request := &library.ListBooksRequest{
+				Parent:   "shelves/1",
+				PageSize: 10,
+			}
+			pageToken, err := ParsePageToken(request)
+			assert.NilError(t, err)
+			pageToken.Cursor = []any{"abc", int64(42)}
+			next := pageToken.Next(request)
+			assert.Equal(t, int64(10), next.Offset)
+			assert.DeepEqual(t, []any{"abc", int64(42)}, next.Cursor)
+		})
+		t.Run("empty cursor round-trips as nil", func(t *testing.T) {
+			t.Parallel()
+			request1 := &library.ListBooksRequest{
+				Parent:   "shelves/1",
+				PageSize: 10,
+			}
+			pageToken1, err := ParsePageToken(request1)
+			assert.NilError(t, err)
+			request2 := &library.ListBooksRequest{
+				Parent:    "shelves/1",
+				PageSize:  10,
+				PageToken: pageToken1.String(),
+			}
+			pageToken2, err := ParsePageToken(request2)
+			assert.NilError(t, err)
+			assert.Assert(t, pageToken2.Cursor == nil)
+		})
+	})
 	t.Run("invalid format", func(t *testing.T) {
 		t.Parallel()
 		request := &library.ListBooksRequest{
@@ -130,7 +181,7 @@ func TestParseOffsetPageToken(t *testing.T) {
 		}
 		pageToken1, err := ParsePageToken(request)
 		assert.ErrorContains(t, err, "decode")
-		assert.Equal(t, PageToken{}, pageToken1)
+		assert.DeepEqual(t, PageToken{}, pageToken1)
 	})
 
 	t.Run("invalid checksum", func(t *testing.T) {
@@ -145,6 +196,6 @@ func TestParseOffsetPageToken(t *testing.T) {
 		}
 		pageToken1, err := ParsePageToken(request)
 		assert.ErrorContains(t, err, "checksum")
-		assert.Equal(t, PageToken{}, pageToken1)
+		assert.DeepEqual(t, PageToken{}, pageToken1)
 	})
 }


### PR DESCRIPTION
 ## Why

  Offset-based pagination works fine for small, stable lists, but it starts hurting once the underlying data shifts under us or the tables grow: offsets drift when rows are inserted/deleted mid-scan, and deep offsets get expensive on the database side. For the list endpoints I'm
  working on, I want the option to paginate by a stable key (an ID, a timestamp, a composite key) instead of counting rows from the start.

  Rather than introduce a parallel token type, I'm extending the existing `PageToken` with an optional `Cursor` field. Endpoints that stick with offset-based pagination don't change — `Cursor` stays `nil`. Endpoints that want key-set pagination can stash whatever key(s) they need
  in `Cursor` and get the existing checksum/encoding machinery for free.

  ## What changed

  - `PageToken` gets a `Cursor []any` field. `[]any` keeps it flexible for composite keys and mixed types without forcing every caller onto the same schema.
  - The cursor round-trips through `String()`/`ParsePageToken` via the existing gob encoder, and `Next()` carries it forward unchanged.
  - Added tests for the round-trip, for `Next()` preserving the cursor, and for the empty-cursor case.
  - Had to switch two existing `assert.Equal(t, PageToken{}, ...)` calls to `assert.DeepEqual` — adding a slice field made `PageToken` uncomparable, which caused those assertions to panic.

 ## Test plan
  - [x] `go test ./pagination/... -run TestParseOffsetPageToken -v`
  - [x] Sanity-check that existing offset-based callers still compile and behave identically (additive field, zero value is `nil`)