### PR TITLE
feat(pagination): add Cursor field and NextCursor for key-set pagination

### DIFF
--- a/pagination/pagetoken.go
+++ b/pagination/pagetoken.go
@@ -2,12 +2,17 @@ package pagination
 
 import (
 	"fmt"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // PageToken is a page token that uses an offset to delineate which page to fetch.
 type PageToken struct {
 	// Offset of the page.
 	Offset int64
+	// Cursor for key set pagination.
+	Cursor []any
 	// RequestChecksum is the checksum of the request that generated the page token.
 	RequestChecksum uint32
 }
@@ -60,6 +65,33 @@ func ParsePageToken(request Request) (_ PageToken, err error) {
 func (p PageToken) Next(request Request) PageToken {
 	p.Offset += int64(request.GetPageSize())
 	return p
+}
+
+// NextCursor returns the next page token for key set pagination by reading the
+// named fields off msg (typically the last row of the current page) into Cursor.
+func (p PageToken) NextCursor(msg proto.Message, fields ...string) (PageToken, error) {
+	r := msg.ProtoReflect()
+	desc := r.Descriptor()
+	cursor := make([]any, 0, len(fields))
+	for _, name := range fields {
+		fd := desc.Fields().ByName(protoreflect.Name(name))
+		if fd == nil {
+			return PageToken{}, fmt.Errorf("next cursor: field %q not found on %s", name, desc.FullName())
+		}
+		if fd.IsList() || fd.IsMap() {
+			return PageToken{}, fmt.Errorf("next cursor: field %q is repeated/map (unsupported)", name)
+		}
+		switch fd.Kind() {
+		case protoreflect.MessageKind, protoreflect.GroupKind:
+			return PageToken{}, fmt.Errorf("next cursor: field %q is a message (unsupported)", name)
+		case protoreflect.EnumKind:
+			cursor = append(cursor, int32(r.Get(fd).Enum()))
+		default:
+			cursor = append(cursor, r.Get(fd).Interface())
+		}
+	}
+	p.Cursor = cursor
+	return p, nil
 }
 
 // String returns a string representation of the page token.

--- a/pagination/pagetoken.go
+++ b/pagination/pagetoken.go
@@ -5,6 +5,8 @@ import (
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // PageToken is a page token that uses an offset to delineate which page to fetch.
@@ -83,7 +85,14 @@ func (p PageToken) NextCursor(msg proto.Message, fields ...string) (PageToken, e
 		}
 		switch fd.Kind() {
 		case protoreflect.MessageKind, protoreflect.GroupKind:
-			return PageToken{}, fmt.Errorf("next cursor: field %q is a message (unsupported)", name)
+			switch m := r.Get(fd).Message().Interface().(type) {
+			case *timestamppb.Timestamp:
+				cursor = append(cursor, m.AsTime())
+			case *durationpb.Duration:
+				cursor = append(cursor, m.AsDuration())
+			default:
+				return PageToken{}, fmt.Errorf("next cursor: field %q is a message (unsupported)", name)
+			}
 		case protoreflect.EnumKind:
 			cursor = append(cursor, int32(r.Get(fd).Enum()))
 		default:

--- a/pagination/pagetoken_test.go
+++ b/pagination/pagetoken_test.go
@@ -2,9 +2,11 @@ package pagination
 
 import (
 	"testing"
+	"time"
 
 	freightv1 "go.einride.tech/aip/proto/gen/einride/example/freight/v1"
 	"google.golang.org/genproto/googleapis/example/library/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"gotest.tools/v3/assert"
 )
 
@@ -238,6 +240,17 @@ func TestParseOffsetPageToken(t *testing.T) {
 			t.Parallel()
 			_, err := PageToken{}.NextCursor(&library.Book{}, "nonexistent")
 			assert.ErrorContains(t, err, "not found")
+		})
+		t.Run("NextCursor reads Timestamp as time.Time", func(t *testing.T) {
+			t.Parallel()
+			moment := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+			shipment := &freightv1.Shipment{
+				Name:       "shippers/1/shipments/42",
+				CreateTime: timestamppb.New(moment),
+			}
+			next, err := PageToken{}.NextCursor(shipment, "create_time")
+			assert.NilError(t, err)
+			assert.DeepEqual(t, []any{moment}, next.Cursor)
 		})
 	})
 	t.Run("invalid format", func(t *testing.T) {

--- a/pagination/pagetoken_test.go
+++ b/pagination/pagetoken_test.go
@@ -121,6 +121,125 @@ func TestParseOffsetPageToken(t *testing.T) {
 			assert.Equal(t, int64(100), pageToken3.Offset)
 		})
 	})
+	t.Run("cursor", func(t *testing.T) {
+		t.Parallel()
+		t.Run("round-trip preserves cursor", func(t *testing.T) {
+			t.Parallel()
+			request1 := &library.ListBooksRequest{
+				Parent:   "shelves/1",
+				PageSize: 10,
+			}
+			pageToken1, err := ParsePageToken(request1)
+			assert.NilError(t, err)
+			pageToken1.Cursor = []any{"abc", int64(42)}
+			request2 := &library.ListBooksRequest{
+				Parent:    "shelves/1",
+				PageSize:  10,
+				PageToken: pageToken1.String(),
+			}
+			pageToken2, err := ParsePageToken(request2)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, []any{"abc", int64(42)}, pageToken2.Cursor)
+		})
+		t.Run("Next preserves cursor", func(t *testing.T) {
+			t.Parallel()
+			request := &library.ListBooksRequest{
+				Parent:   "shelves/1",
+				PageSize: 10,
+			}
+			pageToken, err := ParsePageToken(request)
+			assert.NilError(t, err)
+			pageToken.Cursor = []any{"abc", int64(42)}
+			next := pageToken.Next(request)
+			assert.Equal(t, int64(10), next.Offset)
+			assert.DeepEqual(t, []any{"abc", int64(42)}, next.Cursor)
+		})
+		t.Run("empty cursor round-trips as nil", func(t *testing.T) {
+			t.Parallel()
+			request1 := &library.ListBooksRequest{
+				Parent:   "shelves/1",
+				PageSize: 10,
+			}
+			pageToken1, err := ParsePageToken(request1)
+			assert.NilError(t, err)
+			request2 := &library.ListBooksRequest{
+				Parent:    "shelves/1",
+				PageSize:  10,
+				PageToken: pageToken1.String(),
+			}
+			pageToken2, err := ParsePageToken(request2)
+			assert.NilError(t, err)
+			assert.Assert(t, pageToken2.Cursor == nil)
+		})
+		t.Run("token encoded before cursor field is added", func(t *testing.T) {
+			t.Parallel()
+			// Token shape from before the Cursor field was added.
+			type legacyPageToken struct {
+				Offset          int64
+				RequestChecksum uint32
+			}
+			request := &library.ListBooksRequest{
+				Parent:   "shelves/1",
+				PageSize: 10,
+			}
+			checksum, err := CalculateRequestChecksum(request)
+			assert.NilError(t, err)
+			checksum ^= pageTokenChecksumMask
+			legacy := EncodePageTokenStruct(&legacyPageToken{
+				Offset:          42,
+				RequestChecksum: checksum,
+			})
+			parsed, err := ParsePageToken(&library.ListBooksRequest{
+				Parent:    "shelves/1",
+				PageSize:  10,
+				PageToken: legacy,
+			})
+			assert.NilError(t, err)
+			assert.Equal(t, int64(42), parsed.Offset)
+			assert.Assert(t, parsed.Cursor == nil)
+		})
+		t.Run("NextCursor populates cursor from message fields", func(t *testing.T) {
+			t.Parallel()
+			request := &library.ListBooksRequest{
+				Parent:   "shelves/1",
+				PageSize: 10,
+			}
+			pageToken, err := ParsePageToken(request)
+			assert.NilError(t, err)
+			book := &library.Book{
+				Name:   "shelves/1/books/42",
+				Author: "Ada",
+				Read:   true,
+			}
+			next, err := pageToken.NextCursor(book, "name", "author", "read")
+			assert.NilError(t, err)
+			assert.DeepEqual(t, []any{"shelves/1/books/42", "Ada", true}, next.Cursor)
+		})
+		t.Run("NextCursor round-trips through page token", func(t *testing.T) {
+			t.Parallel()
+			request1 := &library.ListBooksRequest{
+				Parent:   "shelves/1",
+				PageSize: 10,
+			}
+			pageToken1, err := ParsePageToken(request1)
+			assert.NilError(t, err)
+			pageToken1, err = pageToken1.NextCursor(&library.Book{Name: "shelves/1/books/7"}, "name")
+			assert.NilError(t, err)
+			request2 := &library.ListBooksRequest{
+				Parent:    "shelves/1",
+				PageSize:  10,
+				PageToken: pageToken1.String(),
+			}
+			pageToken2, err := ParsePageToken(request2)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, []any{"shelves/1/books/7"}, pageToken2.Cursor)
+		})
+		t.Run("NextCursor errors on unknown field", func(t *testing.T) {
+			t.Parallel()
+			_, err := PageToken{}.NextCursor(&library.Book{}, "nonexistent")
+			assert.ErrorContains(t, err, "not found")
+		})
+	})
 	t.Run("invalid format", func(t *testing.T) {
 		t.Parallel()
 		request := &library.ListBooksRequest{
@@ -130,7 +249,7 @@ func TestParseOffsetPageToken(t *testing.T) {
 		}
 		pageToken1, err := ParsePageToken(request)
 		assert.ErrorContains(t, err, "decode")
-		assert.Equal(t, PageToken{}, pageToken1)
+		assert.DeepEqual(t, PageToken{}, pageToken1)
 	})
 
 	t.Run("invalid checksum", func(t *testing.T) {
@@ -145,6 +264,6 @@ func TestParseOffsetPageToken(t *testing.T) {
 		}
 		pageToken1, err := ParsePageToken(request)
 		assert.ErrorContains(t, err, "checksum")
-		assert.Equal(t, PageToken{}, pageToken1)
+		assert.DeepEqual(t, PageToken{}, pageToken1)
 	})
 }


### PR DESCRIPTION
## Summary

- Add `Cursor []any` to `PageToken` so a single opaque token can carry key-set state alongside `Offset`.
- Add `PageToken.NextCursor(msg proto.Message, fields ...string) (PageToken, error)` — reads named fields off `msg` (typically the last row of the current page) via `protoreflect` and stores them in `Cursor`. Enums are normalized to `int32`; repeated/map/message fields are rejected.
- `Next(request)` continues to advance `Offset` for offset-style pagination. The two modes are independent on the same token.

## Why both on one token

Per [AIP-158](https://google.aip.dev/158#page-tokens), `page_token` is server-opaque — the server defines its contents. Offset (via [`skip`](https://google.aip.dev/158#skipping-results)) and key-set cursors are complementary, not mutually exclusive. A handler can issue offset tokens for early pages and switch to cursor tokens once a stable ordering key is available, all behind the same opaque string.

Keeping both fields on one struct:
- lets handlers switch modes mid-stream without changing token type
- preserves backward compatibility — legacy `{Offset, RequestChecksum}` tokens gob-decode with `Cursor` left `nil` (covered by an existing legacy-decode test)
- keeps `RequestChecksum` as the single guard against request drift between pages

## Test plan

- [x] `go test ./pagination/` — existing suite + new cursor round-trip, `NextCursor` population, and unknown-field error tests pass
- [x] legacy token decode verified (pre-`Cursor` token shape still parses with `Cursor == nil`)