### PR TITLE
fix: avoid race condition on filter declarations

### DIFF
--- a/filtering/declarations.go
+++ b/filtering/declarations.go
@@ -222,6 +222,25 @@ func (d *Declarations) declare(decl *expr.Decl) error {
 	}
 }
 
+// clone returns a shallow copy of the declarations.
+func (d *Declarations) clone() *Declarations {
+	cloned := &Declarations{
+		idents:    make(map[string]*expr.Decl, len(d.idents)),
+		functions: make(map[string]*expr.Decl, len(d.functions)),
+		enums:     make(map[string]protoreflect.EnumType, len(d.enums)),
+	}
+	for k, v := range d.idents {
+		cloned.idents[k] = v
+	}
+	for k, v := range d.functions {
+		cloned.functions[k] = v
+	}
+	for k, v := range d.enums {
+		cloned.enums[k] = v
+	}
+	return cloned
+}
+
 // merge merges the given declarations into the current declarations.
 // Given declarations take precedence over current declarations in case
 // of conflicts (such as same identifier name but different type or same function name but different definition).

--- a/filtering/filter.go
+++ b/filtering/filter.go
@@ -11,6 +11,8 @@ type Filter struct {
 }
 
 // ApplyMacros modifies the filter by applying the provided macros.
+// It is safe to call ApplyMacros concurrently on filters that share the same
+// underlying *Declarations.
 // EXPERIMENTAL: This method is experimental and may be changed or removed in the future.
 func (f *Filter) ApplyMacros(macros ...Macro) error {
 	declarationOptions, err := applyMacros(
@@ -26,6 +28,8 @@ func (f *Filter) ApplyMacros(macros ...Macro) error {
 	if err != nil {
 		return err
 	}
+	// Clone the declarations to avoid mutating any other filters that share the same underlying *Declarations.
+	f.declarations = f.declarations.clone()
 	f.declarations.merge(newDeclarations)
 	var checker Checker
 	checker.Init(f.CheckedExpr.GetExpr(), f.CheckedExpr.GetSourceInfo(), f.declarations)

--- a/filtering/filter_test.go
+++ b/filtering/filter_test.go
@@ -1,6 +1,7 @@
 package filtering
 
 import (
+	"sync"
 	"testing"
 
 	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
@@ -319,4 +320,36 @@ func TestFilter_ApplyMacros(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFilter_ApplyMacros_ConcurrentSharedDeclarations verifies that calling
+// ApplyMacros concurrently on filters that share the same *Declarations does
+// not cause a data race. Run with -race to detect violations.
+func TestFilter_ApplyMacros_ConcurrentSharedDeclarations(t *testing.T) {
+	t.Parallel()
+	decl, err := NewDeclarations(
+		DeclareStandardFunctions(),
+		DeclareIdent("name", TypeString),
+	)
+	assert.NilError(t, err)
+	macro := func(cursor *Cursor) {
+		identExpr := cursor.Expr().GetIdentExpr()
+		if identExpr == nil || identExpr.GetName() != "name" {
+			return
+		}
+		cursor.ReplaceWithDeclarations(
+			Text("renamed"),
+			[]DeclarationOption{DeclareIdent("renamed", TypeString)},
+		)
+	}
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			filter, ferr := ParseFilter(&mockRequest{filter: `name = "test"`}, decl)
+			assert.NilError(t, ferr)
+			merr := filter.ApplyMacros(macro)
+			assert.NilError(t, merr)
+		})
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Fix data race by cloning the filter declarations in Filter.ApplyMacros before modifying them.

This allows the user to keep a 'static' filterDeclarations instance on service layer and run ApplyMacros per request without causing race conditions between concurrent requests.