### PR TITLE
fix: prevent race conditions when retrying transactions

### DIFF
--- a/filtering/filter.go
+++ b/filtering/filter.go
@@ -2,6 +2,7 @@ package filtering
 
 import (
 	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"google.golang.org/protobuf/proto"
 )
 
 // Filter represents a parsed and type-checked filter.
@@ -10,33 +11,43 @@ type Filter struct {
 	declarations *Declarations
 }
 
-// ApplyMacros modifies the filter by applying the provided macros.
-// It is safe to call ApplyMacros concurrently on filters that share the same
-// underlying *Declarations.
+// WithMacros returns a new Filter with the given macros applied and the
+// result type-checked. f is not modified.
+//
+// It is safe to call WithMacros concurrently on filters that share the same
+// underlying *Declarations, and safe to call repeatedly on the same Filter
+// (e.g. when retrying a Spanner transaction): f.CheckedExpr is cloned before
+// rewriting, so f retains its original expression tree on every invocation.
+//
 // EXPERIMENTAL: This method is experimental and may be changed or removed in the future.
-func (f *Filter) ApplyMacros(macros ...Macro) error {
+func (f Filter) WithMacros(macros ...Macro) (Filter, error) {
+	// Clone the CheckedExpr so the macro rewrite does not mutate f's
+	// expression tree.
+	rewritten := proto.CloneOf(f.CheckedExpr)
 	declarationOptions, err := applyMacros(
-		f.CheckedExpr.GetExpr(),
-		f.CheckedExpr.GetSourceInfo(),
+		rewritten.GetExpr(),
+		rewritten.GetSourceInfo(),
 		f.declarations,
 		macros...,
 	)
 	if err != nil {
-		return err
+		return Filter{}, err
 	}
 	newDeclarations, err := NewDeclarations(declarationOptions...)
 	if err != nil {
-		return err
+		return Filter{}, err
 	}
-	// Clone the declarations to avoid mutating any other filters that share the same underlying *Declarations.
-	f.declarations = f.declarations.clone()
-	f.declarations.merge(newDeclarations)
+	// Clone declarations so f.declarations is not mutated.
+	declarations := f.declarations.clone()
+	declarations.merge(newDeclarations)
 	var checker Checker
-	checker.Init(f.CheckedExpr.GetExpr(), f.CheckedExpr.GetSourceInfo(), f.declarations)
+	checker.Init(rewritten.GetExpr(), rewritten.GetSourceInfo(), declarations)
 	checkedExpr, err := checker.Check()
 	if err != nil {
-		return err
+		return Filter{}, err
 	}
-	f.CheckedExpr = checkedExpr
-	return nil
+	return Filter{
+		CheckedExpr:  checkedExpr,
+		declarations: declarations,
+	}, nil
 }

--- a/filtering/filter_test.go
+++ b/filtering/filter_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"gotest.tools/v3/assert"
 )
 
-func TestFilter_ApplyMacros(t *testing.T) {
+func TestFilter_WithMacros(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
 		name          string
@@ -294,10 +295,10 @@ func TestFilter_ApplyMacros(t *testing.T) {
 			t.Parallel()
 			declarations, err := NewDeclarations(tt.declarations...)
 			assert.NilError(t, err)
-			filter, err := ParseFilter(&mockRequest{filter: tt.filter}, declarations)
+			source, err := ParseFilter(&mockRequest{filter: tt.filter}, declarations)
 			assert.NilError(t, err)
 
-			err = filter.ApplyMacros(tt.macros...)
+			result, err := source.WithMacros(tt.macros...)
 			if err != nil && tt.errorContains != "" {
 				assert.ErrorContains(t, err, tt.errorContains)
 				return
@@ -308,12 +309,11 @@ func TestFilter_ApplyMacros(t *testing.T) {
 			}
 			assert.NilError(t, err)
 
-			// Verify filter was modified in place
 			if tt.expected != nil {
 				assert.DeepEqual(
 					t,
 					tt.expected,
-					filter.CheckedExpr.GetExpr(),
+					result.CheckedExpr.GetExpr(),
 					protocmp.Transform(),
 					protocmp.IgnoreFields(&expr.Expr{}, "id"),
 				)
@@ -322,10 +322,10 @@ func TestFilter_ApplyMacros(t *testing.T) {
 	}
 }
 
-// TestFilter_ApplyMacros_ConcurrentSharedDeclarations verifies that calling
-// ApplyMacros concurrently on filters that share the same *Declarations does
+// TestFilter_WithMacros_ConcurrentSharedDeclarations verifies that calling
+// WithMacros concurrently on filters that share the same *Declarations does
 // not cause a data race. Run with -race to detect violations.
-func TestFilter_ApplyMacros_ConcurrentSharedDeclarations(t *testing.T) {
+func TestFilter_WithMacros_ConcurrentSharedDeclarations(t *testing.T) {
 	t.Parallel()
 	decl, err := NewDeclarations(
 		DeclareStandardFunctions(),
@@ -347,9 +347,109 @@ func TestFilter_ApplyMacros_ConcurrentSharedDeclarations(t *testing.T) {
 		wg.Go(func() {
 			filter, ferr := ParseFilter(&mockRequest{filter: `name = "test"`}, decl)
 			assert.NilError(t, ferr)
-			merr := filter.ApplyMacros(macro)
+			_, merr := filter.WithMacros(macro)
 			assert.NilError(t, merr)
 		})
 	}
 	wg.Wait()
+}
+
+// TestFilter_WithMacros_Retry verifies that calling WithMacros repeatedly on
+// the same source Filter is idempotent: each call produces an equivalent
+// rewritten expression and the source's CheckedExpr is never mutated. This
+// pattern occurs in practice when a Spanner read-write transaction is retried
+// — the driver invokes the callback (and therefore WithMacros) again with the
+// same source Filter, and the second attempt must observe a pristine tree.
+func TestFilter_WithMacros_Retry(t *testing.T) {
+	t.Parallel()
+	decl, err := NewDeclarations(
+		DeclareStandardFunctions(),
+		DeclareIdent("name", TypeString),
+	)
+	assert.NilError(t, err)
+	macro := func(cursor *Cursor) {
+		identExpr := cursor.Expr().GetIdentExpr()
+		if identExpr == nil || identExpr.GetName() != "name" {
+			return
+		}
+		cursor.ReplaceWithDeclarations(
+			Text("renamed"),
+			[]DeclarationOption{DeclareIdent("renamed", TypeString)},
+		)
+	}
+	source, err := ParseFilter(&mockRequest{filter: `name = "test"`}, decl)
+	assert.NilError(t, err)
+	// Snapshot the original expression so we can verify the source is never mutated.
+	originalExpr := proto.CloneOf(source.CheckedExpr)
+	want := Equals(Text("renamed"), String("test"))
+	for i := range 3 {
+		result, werr := source.WithMacros(macro)
+		assert.NilError(t, werr, "WithMacros call %d", i)
+		assert.DeepEqual(
+			t,
+			want,
+			result.CheckedExpr.GetExpr(),
+			protocmp.Transform(),
+			protocmp.IgnoreFields(&expr.Expr{}, "id"),
+		)
+		// The source must remain pristine across calls.
+		assert.DeepEqual(
+			t,
+			originalExpr,
+			source.CheckedExpr,
+			protocmp.Transform(),
+		)
+	}
+}
+
+// TestFilter_WithMacros_Chain verifies that WithMacros can be chained — feeding
+// the result of one call back into another — and that each intermediate Filter
+// retains its own expression tree.
+func TestFilter_WithMacros_Chain(t *testing.T) {
+	t.Parallel()
+	decl, err := NewDeclarations(
+		DeclareStandardFunctions(),
+		DeclareIdent("name", TypeString),
+	)
+	assert.NilError(t, err)
+	renameTo := func(from, to string) Macro {
+		return func(cursor *Cursor) {
+			identExpr := cursor.Expr().GetIdentExpr()
+			if identExpr == nil || identExpr.GetName() != from {
+				return
+			}
+			cursor.ReplaceWithDeclarations(
+				Text(to),
+				[]DeclarationOption{DeclareIdent(to, TypeString)},
+			)
+		}
+	}
+	source, err := ParseFilter(&mockRequest{filter: `name = "test"`}, decl)
+	assert.NilError(t, err)
+	step1, err := source.WithMacros(renameTo("name", "step1"))
+	assert.NilError(t, err)
+	step2, err := step1.WithMacros(renameTo("step1", "step2"))
+	assert.NilError(t, err)
+
+	assert.DeepEqual(
+		t,
+		Equals(Text("name"), String("test")),
+		source.CheckedExpr.GetExpr(),
+		protocmp.Transform(),
+		protocmp.IgnoreFields(&expr.Expr{}, "id"),
+	)
+	assert.DeepEqual(
+		t,
+		Equals(Text("step1"), String("test")),
+		step1.CheckedExpr.GetExpr(),
+		protocmp.Transform(),
+		protocmp.IgnoreFields(&expr.Expr{}, "id"),
+	)
+	assert.DeepEqual(
+		t,
+		Equals(Text("step2"), String("test")),
+		step2.CheckedExpr.GetExpr(),
+		protocmp.Transform(),
+		protocmp.IgnoreFields(&expr.Expr{}, "id"),
+	)
 }


### PR DESCRIPTION
The Filter.ApplyMacros method mutated the CheckedExpr property when creating new Declarations.
This caused a race condition when a transaction is re-tried due to a Spanner Aborted error.

The fix is to clone the expression before mutating it. Since the method now clones the Filter pointers rather than mutating them, it is changed from ApplyMacros to WithMacros, returning a new Filter.

It is now safe to call WithMacros multiple times on the same Filter instance, both concurrently (when multiple RPCs are called at the same time) and sequentially (when a transaction is re-tried).